### PR TITLE
fix: make List-Unsubscribe auto-generation opt-in for transactional sends

### DIFF
--- a/docs/docs/email-sending/single-email.md
+++ b/docs/docs/email-sending/single-email.md
@@ -27,6 +27,7 @@ curl -X POST http://localhost:9000/api/v1/emails/send \
     "headers": {
       "X-Campaign-ID": "report-2026-01"
     },
+    "list_unsubscribe": true,
     "list_unsubscribe_url": "https://example.com/unsubscribe"
   }'
 ```
@@ -47,7 +48,7 @@ Response:
 
 - **HTML and plain text** — Send both for maximum client compatibility
 - **Custom headers** — Add arbitrary headers like `X-Campaign-ID`
-- **List-Unsubscribe** — Include unsubscribe URL and one-click POST support
+- **List-Unsubscribe** — Opt-in via `list_unsubscribe: true`. When enabled, an RFC 8058 one-click unsubscribe URL is auto-generated if you don't supply your own `list_unsubscribe_url`. Set `list_unsubscribe_post: true` to additionally advertise the `List-Unsubscribe-Post` header
 - **Scheduled delivery** — Set `send_at` to deliver at a specific time (see [Scheduled Email](/docs/email-sending/scheduled-email))
 - **Attachments** — Attach base64-encoded files (see [Attachments](/docs/email-sending/attachments))
 - **Dry run** — Add `?dry_run=true` to validate the request without sending

--- a/internal/models/email.go
+++ b/internal/models/email.go
@@ -51,6 +51,7 @@ type Email struct {
 	HeadersJSON         string         `json:"headers_json,omitempty" gorm:"type:text"`
 	ListUnsubscribeURL  string         `json:"list_unsubscribe_url,omitempty" gorm:"type:text"`
 	ListUnsubscribePost bool           `json:"list_unsubscribe_post,omitempty"`
+	ListUnsubscribe     bool           `json:"list_unsubscribe,omitempty"`
 	Status              EmailStatus    `json:"status" gorm:"default:pending;not null"`
 	ErrorMessage        string         `json:"error_message"`
 	RetryCount          int            `json:"retry_count" gorm:"default:0;not null"`

--- a/internal/services/email/service.go
+++ b/internal/services/email/service.go
@@ -152,8 +152,8 @@ func (s *Service) SetEnqueuer(eq EmailEnqueuer) {
 }
 
 // SetTxUnsubscribeGenerator wires the one-click unsubscribe URL generator.
-// When set, transactional sends that use a subscriber list but don't supply an
-// explicit list_unsubscribe_url will get an auto-generated RFC 8058 URL.
+// When set, transactional sends that have list_unsubscribe enabled but don't
+// supply an explicit list_unsubscribe_url will get an auto-generated RFC 8058 URL.
 func (s *Service) SetTxUnsubscribeGenerator(gen TxUnsubscribeGenerator) {
 	s.txUnsubGen = gen
 }
@@ -239,6 +239,7 @@ type SendRequest struct {
 	Headers             map[string]string   `json:"headers,omitempty"`
 	ListUnsubscribeURL  string              `json:"list_unsubscribe_url,omitempty"`
 	ListUnsubscribePost bool                `json:"list_unsubscribe_post,omitempty"`
+	ListUnsubscribe     bool                `json:"list_unsubscribe,omitempty"`
 	SendAt              *time.Time          `json:"send_at,omitempty"`
 	// TemplateName is populated by internal template-send paths
 	TemplateName string `json:"-"`
@@ -615,6 +616,7 @@ func (s *Service) Send(ctx context.Context, userID, apiKeyID uint, workspaceID *
 		HeadersJSON:         headersJSON,
 		ListUnsubscribeURL:  req.ListUnsubscribeURL,
 		ListUnsubscribePost: req.ListUnsubscribePost,
+		ListUnsubscribe:     req.ListUnsubscribe,
 		Status:              models.EmailStatusPending,
 		Provider:            ClassifyRecipients(req.To),
 	}
@@ -624,10 +626,9 @@ func (s *Service) Send(ctx context.Context, userID, apiKeyID uint, workspaceID *
 	}
 
 	// Auto-attach an RFC 8058 one-click unsubscribe URL for transactional sends
-	// when the caller did not supply their own.
-	if em.ListUnsubscribeURL == "" && s.txUnsubGen != nil {
+	// when the caller opted in via list_unsubscribe but did not supply their own URL.
+	if em.ListUnsubscribeURL == "" && s.txUnsubGen != nil && em.ListUnsubscribe {
 		em.ListUnsubscribeURL = s.txUnsubGen.TxUnsubscribeURL(em.ID)
-		em.ListUnsubscribePost = true
 		_ = s.emailRepo.Update(em)
 	}
 


### PR DESCRIPTION
## Problem

The email service unconditionally auto-generates `List-Unsubscribe` and `List-Unsubscribe-Post` headers for **every** transactional email when no explicit URL is provided.

Additionally, `list_unsubscribe_post` was forced to `true` regardless of the caller's value.

## Solution

Add a new `list_unsubscribe` boolean field (default `false`) that acts as a master opt-in toggle:

- **Auto-generation only triggers** when `list_unsubscribe: true` is explicitly set
- The caller's `list_unsubscribe_post` value is **respected** (no longer overwritten)
- Callers who pass an explicit `list_unsubscribe_url` continue to work as before
- Campaign/bulk sends are unaffected (they have their own unsubscribe logic)

## Changes

- `internal/models/email.go` — New `ListUnsubscribe bool` column
- `internal/services/email/service.go` — New field on `SendRequest`, gate auto-generation behind `em.ListUnsubscribe`, remove forced `ListUnsubscribePost = true`
- `docs/docs/email-sending/single-email.md` — Updated example and feature description

## Backward Compatibility

- Default is `false` → existing callers that don't send the field will **no longer** get auto-generated unsubscribe headers (this is the fix)
- Callers who want auto-generation must now explicitly opt in with `"list_unsubscribe": true`

Fixes #74 