### PR TITLE
add template edit modal and minor UI/theme fixes

### DIFF
--- a/web/src/assets/styles.css
+++ b/web/src/assets/styles.css
@@ -164,7 +164,22 @@ a:hover { color: var(--primary-600); }
   background: var(--primary-700);
   border-color: var(--primary-700);
 }
+.btn-outline-primary {
+  background: transparent;
+  color: var(--primary-600);
+  border: 1px solid var(--primary-600);
+}
 
+.btn-outline-primary:hover:not(:disabled) {
+  background: var(--primary-400);
+  color: var(--text-on-primary);
+  border-color: var(--primary-300); 
+}
+
+[data-theme="dark"] .btn-outline-primary:hover:not(:disabled)  {
+  background: var(--primary-900);
+  border-color: var(--primary-700); 
+}
 .btn-secondary {
   background: var(--bg-primary);
   color: var(--text-secondary);

--- a/web/src/assets/styles.css
+++ b/web/src/assets/styles.css
@@ -638,6 +638,10 @@ tr:hover td { background: var(--bg-hover); }
   overflow-x: auto;
   user-select: all;
   border: 1px solid var(--border-primary);
+  max-width: 100%;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 /* ─── DNS Records ─── */

--- a/web/src/assets/styles.css
+++ b/web/src/assets/styles.css
@@ -172,8 +172,8 @@ a:hover { color: var(--primary-600); }
 
 .btn-outline-primary:hover:not(:disabled) {
   background: var(--primary-400);
-  color: var(--text-on-primary);
   border-color: var(--primary-300); 
+  color: var(--text-on-primary);
 }
 
 [data-theme="dark"] .btn-outline-primary:hover:not(:disabled)  {
@@ -641,6 +641,51 @@ tr:hover td { background: var(--bg-hover); }
   cursor: pointer;
 }
 .checkbox-label input[type="checkbox"] { width: 16px; height: 16px; accent-color: var(--primary-600); }
+
+input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  
+  background-color: var(--bg-input);
+  border: 1px solid var(--border-input);
+  
+  display: inline-grid;
+  place-content: center;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+input[type="checkbox"]:hover:not(:disabled) {
+  border-color: var(--border-focus);
+}
+
+input[type="checkbox"]:checked {
+  background-color: var(--primary-600);
+  border-color: var(--primary-600);
+}
+
+input[type="checkbox"]::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  background-color: var(--text-on-primary);
+  
+  mask: var(--checkmark) no-repeat center;
+  -webkit-mask: var(--checkmark) no-repeat center;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  
+  transform: scale(0);
+  transition: transform 0.1s ease-in-out;
+}
+
+input[type="checkbox"]:checked::before {
+  transform: scale(1);
+}
 
 /* ─── Code block ─── */
 .code-block {

--- a/web/src/components/TemplateModal.vue
+++ b/web/src/components/TemplateModal.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { languagesApi } from '@/api/languages';
+import { Language, Template, TemplateInput } from '@/api/types';
+import { useModalSafeClose } from '@/composables/useModalSafeClose';
+import { onMounted, ref } from 'vue';
+
+interface Props {
+  form: TemplateInput
+  isVisible?: boolean
+  saving?: boolean 
+  editing?: Template | null
+}
+const props = withDefaults(defineProps<Props>(), {
+  isVisible: false,
+  saving: false,
+  editing: null
+})
+const languages = ref<Language[]>([]);
+
+async function loadLanguages() {
+  try {
+    const res = await languagesApi.list(0, 100);
+    languages.value = res.data.data;
+  } catch {
+    // Non-critical
+  }
+}
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'save'): void
+}>()
+
+const { watchClickStart, confirmClickEnd } = useModalSafeClose(() => {
+  emit('close')
+});
+
+onMounted(() => {
+  loadLanguages();
+});
+</script>
+
+<template>
+  <div v-if="isVisible" class="modal-overlay" @mousedown="watchClickStart" @mouseup="confirmClickEnd">
+    <div class="modal" style="max-width: 560px" @mousedown.stop @mouseup.stop>
+      <div class="modal-header">
+        <h3>{{ editing ? "Edit Template" : "Create Template" }}</h3>
+      </div>
+
+      <div class="modal-body">
+        <div class="form-group">
+          <label class="form-label">Name</label>
+          <input v-model="form.name" class="form-input" placeholder="e.g. Welcome Email" />
+        </div>
+        <div class="form-group">
+          <label class="form-label">Description</label>
+          <input v-model="form.description" class="form-input" placeholder="e.g. Sent after user registration" />
+        </div>
+        <div class="form-group">
+          <label class="form-label">Default Language</label>
+          <select v-model="form.default_language" class="form-select">
+            <option v-for="lang in languages" :key="lang.id" :value="lang.code">
+              {{ lang.name }} ({{ lang.code }})
+            </option>
+          </select>
+          <span class="form-hint">Fallback language when no localization matches the requested language</span>
+        </div>
+        <div class="form-group">
+          <label class="form-label">Sample Data (JSON)</label>
+          <textarea v-model="form.sample_data" class="form-textarea" rows="3"
+            placeholder='{"name": "John", "company": "Acme"}'></textarea>
+          <span class="form-hint">Default sample data for previewing template localizations</span>
+        </div>
+      </div>
+
+      <div class="modal-footer">
+        <button class="btn btn-secondary" @click="emit('close')">Cancel</button>
+        <button class="btn btn-primary" :disabled="saving || !form.name.trim()" @click="emit('save')">
+          {{ saving ? "Saving..." : editing ? "Update" : "Create" }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/views/templates/TemplateDetail.vue
+++ b/web/src/views/templates/TemplateDetail.vue
@@ -12,11 +12,13 @@ import type {
   TemplatePreview,
   StyleSheet,
   Language,
+  TemplateInput,
 } from "../../api/types";
 import { useNotificationStore } from "../../stores/notification";
 import { useConfirm } from "../../composables/useConfirm";
 import { useModalSafeClose } from "../../composables/useModalSafeClose";
 import { useWorkspaceStore } from "../../stores/workspace";
+import TemplateModal from "@/components/TemplateModal.vue";
 
 const route = useRoute();
 const router = useRouter();
@@ -79,6 +81,17 @@ const showVersionStylesheetModal = ref(false);
 const editingVersion = ref<TemplateVersion | null>(null);
 const editVersionStylesheetId = ref<number | null>(null);
 const savingVersionStylesheet = ref(false);
+
+//template modal
+const savingTemplate = ref(false);
+const showTemplateEditModal = ref(false);
+const templateForm = ref<TemplateInput>({
+  name: "",
+  sample_data: "",
+  default_language: "en",
+  description: "",
+});
+
 
 const isActive = computed(() => (v: TemplateVersion) =>
   template.value?.active_version_id === v.id
@@ -376,6 +389,35 @@ function openPreview(lang: string) {
   renderPreview();
 }
 
+function openEditTemplate() {
+  if(!template.value) return
+  templateForm.value = {
+    name: template.value.name,
+    sample_data: template.value.sample_data || "",
+    default_language: template.value.default_language || "en",
+    description: template.value.description || "",
+  };
+  showTemplateEditModal.value = true;
+}
+async function saveTemplate() {
+  if (!templateForm.value.name.trim()) return;
+  if (!template.value) return
+  savingTemplate.value = true;
+  try {
+    
+      await templatesApi.update(template.value?.id, templateForm.value);
+      notify.success("Template updated");
+   
+    closeActiveModal();
+    loadAll()
+  } catch {
+    notify.error(
+    "Failed to update template"
+    );
+  } finally {
+    savingTemplate.value = false;
+  }
+}
 function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString(undefined, {
     year: "numeric",
@@ -389,6 +431,7 @@ const closeActiveModal = () => {
   if (showPreview.value) showPreview.value = false;
   if (showSendTest.value) showSendTest.value = false;
   if (showLocModal.value) showLocModal.value = false;
+  if (showTemplateEditModal.value) showTemplateEditModal.value = false;
 };
 
 const { watchClickStart, confirmClickEnd } = useModalSafeClose(() => {
@@ -408,6 +451,9 @@ onMounted(loadAll);
           :disabled="!template?.active_version_id"
         >
           Send Test
+        </button>
+        <button class="btn btn-outline-primary" @click="openEditTemplate">
+          Edit Template
         </button>
         <button class="btn btn-secondary" @click="router.push('/templates')">
           Back to Templates
@@ -865,6 +911,8 @@ onMounted(loadAll);
         </div>
       </div>
     </div>
+
+    <TemplateModal :editing="template" :is-visible="showTemplateEditModal" :saving="savingTemplate" :form="templateForm" @close="closeActiveModal" @save="saveTemplate" />
   </div>
 </template>
 

--- a/web/src/views/templates/Templates.vue
+++ b/web/src/views/templates/Templates.vue
@@ -16,8 +16,7 @@ import { useModalSafeClose } from "../../composables/useModalSafeClose";
 import { useWorkspaceStore } from "../../stores/workspace";
 import { usePagination } from '@/composables/usePagination'
 import Pagination from '@/components/Pagination.vue'
-
-
+import TemplateModal from "@/components/TemplateModal.vue";
 
 const router = useRouter();
 const notify = useNotificationStore();
@@ -353,70 +352,8 @@ onMounted(() => {
     </div>
 
     <!-- Create/Edit Template Modal -->
-    <div
-      v-if="showModal"
-      class="modal-overlay"
-      @mousedown="watchClickStart"
-      @mouseup="confirmClickEnd"
-    >
-      <div class="modal" style="max-width: 560px" @mousedown.stop @mouseup.stop>
-        <div class="modal-header">
-          <h3>{{ editing ? "Edit Template" : "Create Template" }}</h3>
-        </div>
-
-        <div class="modal-body">
-          <div class="form-group">
-            <label class="form-label">Name</label>
-            <input
-              v-model="form.name"
-              class="form-input"
-              placeholder="e.g. Welcome Email"
-            />
-          </div>
-          <div class="form-group">
-            <label class="form-label">Description</label>
-            <input
-              v-model="form.description"
-              class="form-input"
-              placeholder="e.g. Sent after user registration"
-            />
-          </div>
-          <div class="form-group">
-            <label class="form-label">Default Language</label>
-            <select v-model="form.default_language" class="form-select">
-              <option v-for="lang in languages" :key="lang.id" :value="lang.code">
-                {{ lang.name }} ({{ lang.code }})
-              </option>
-            </select>
-            <span class="form-hint"
-              >Fallback language when no localization matches the requested language</span
-            >
-          </div>
-          <div class="form-group">
-            <label class="form-label">Sample Data (JSON)</label>
-            <textarea
-              v-model="form.sample_data"
-              class="form-textarea"
-              rows="3"
-              placeholder='{"name": "John", "company": "Acme"}'
-            ></textarea>
-            <span class="form-hint"
-              >Default sample data for previewing template localizations</span
-            >
-          </div>
-        </div>
-
-        <div class="modal-footer">
-          <button class="btn btn-secondary" @click="closeModal">Cancel</button>
-          <button
-            class="btn btn-primary"
-            :disabled="saving || !form.name.trim()"
-            @click="saveTemplate"
-          >
-            {{ saving ? "Saving..." : editing ? "Update" : "Create" }}
-          </button>
-        </div>
-      </div>
-    </div>
+     <TemplateModal :editing="editing" :is-visible="showModal" :saving="saving" :form="form"
+      @close="closeModal" @save="saveTemplate" />
+   
   </div>
 </template>

--- a/web/src/views/unsubscribe-lists/UnsubscribeListDetail.vue
+++ b/web/src/views/unsubscribe-lists/UnsubscribeListDetail.vue
@@ -75,7 +75,15 @@ onMounted(async () => {
   <div>
     <div class="page-header">
       <div>
-        <a class="link" @click="router.push({ name: 'unsubscribe-lists-page' })">← Unsubscribe Lists</a>
+        <a class="link cursor-pointer" @click="router.push({ name: 'unsubscribe-lists-page' })"> 
+          <svg
+            xmlns="http://www.w3.org/2000/svg" width="16" height="12" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="19" y1="12" x2="5" y2="12"></line>
+            <polyline points="12 19 5 12 12 5"></polyline>
+          </svg>
+
+          Unsubscribe Lists</a>
         <h1 v-if="list">{{ list.name }}</h1>
       </div>
     </div>
@@ -86,6 +94,7 @@ onMounted(async () => {
 
     <template v-else-if="list">
       <div class="card" style="margin-bottom: 16px;">
+        <div class="card-header">
         <div style="display: flex; flex-wrap: wrap; gap: 32px;">
           <div>
             <div class="form-hint">Opt-outs</div>
@@ -109,6 +118,7 @@ onMounted(async () => {
           </div>
         </div>
         <p v-if="list.description" style="margin-top: 16px; color: var(--text-secondary, #6b7280);">{{ list.description }}</p>
+      </div>
       </div>
 
       <div class="card">

--- a/web/src/views/unsubscribe-lists/UnsubscribeLists.vue
+++ b/web/src/views/unsubscribe-lists/UnsubscribeLists.vue
@@ -189,9 +189,9 @@ const { watchClickStart, confirmClickEnd } = useModalSafeClose(() => {
               </tr>
             </thead>
             <tbody>
-              <tr v-for="list in lists" :key="list.id">
+              <tr v-for="list in lists" :key="list.id" @click="router.push(`/unsubscribe-lists/${list.id}`)" class="cursor-pointer">
                 <td>
-                  <a class="link" @click="router.push(`/unsubscribe-lists/${list.id}`)">{{ list.name }}</a>
+                  <a class="link">{{ list.name }}</a>
                   <span
                     class="badge badge-neutral"
                     :title="`Copy list ID ${list.id}`"
@@ -208,9 +208,9 @@ const { watchClickStart, confirmClickEnd } = useModalSafeClose(() => {
                 <td>{{ formatDate(list.created_at) }}</td>
                 <td>
                   <div class="flex gap-2">
-                    <button class="btn btn-secondary btn-sm" @click="router.push(`/unsubscribe-lists/${list.id}`)">View</button>
-                    <button v-if="wsStore.canEdit" class="btn btn-secondary btn-sm" @click="openEdit(list)">Edit</button>
-                    <button v-if="wsStore.canEdit" class="btn btn-danger btn-sm" @click="deleteList(list)">Delete</button>
+                    <button class="btn btn-secondary btn-sm" @click.stop="router.push(`/unsubscribe-lists/${list.id}`)">View</button>
+                    <button v-if="wsStore.canEdit" class="btn btn-secondary btn-sm" @click.stop="openEdit(list)">Edit</button>
+                    <button v-if="wsStore.canEdit" class="btn btn-danger btn-sm" @click.stop="deleteList(list)">Delete</button>
                   </div>
                 </td>
               </tr>


### PR DESCRIPTION
This PR bundles a few UI cleanups and a new component for managing templates. The main additions are an edit modal for templates, theme fixes for checkboxes, and some layout adjustments for code blocks and the unsubscriber list.

#What's Changing?

-  Features

Template Editing: Added a new TemplateEditModal component. You'll now find an edit button on the template detail page that triggers this modal, and it's wired into the main template pages.

- Fixes & UI Tweaks

	- Code Block Overflows: Fixed an issue where raw HTML template code blocks would blow past their containers and break the layout.
	- Theming: Added dedicated styles for checkboxes so they look right and stay readable in both light and dark modes.
	- Unsubscriber List: Brushed up the styles on the UnsubscriberList pages to clean up the alignment and overall look.

- How to Review

	- Check the Modal: Go to a template detail page or teemplate list page, click the edit or create button, and make sure the TemplateEditModal opens and handles updates correctly.
	- 
	- Test Code Layouts: Open a template with a long HTML code snippet to verify that the block wraps or scrolls nicely without breaking the page width.
	- 
	- Toggle Themes: Switch between dark and light modes on any page with checkboxes to ensure the custom styles render properly.
	- 
	- Verify Lists: Take a quick look at the UnsubscriberList pages to confirm the UI adjustments look solid.