### PR TITLE
feat(web): embed the dashboard in the binary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,6 @@ README.md
 LICENSE
 web/node_modules
 web/dist
+# Never ship a locally staged dashboard build into the image: the Dockerfile
+# builds the UI itself and copies it to internal/web/dist for embedding.
+internal/web/dist

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 bin/
 .history
 .DS_Store
+
+# Embedded dashboard: the built assets are a `make build-ui` artifact baked into
+# the binary by //go:embed, not source. Only the placeholder is committed so
+# `go build` works on a clean checkout.
+/internal/web/dist/*
+!/internal/web/dist/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,23 @@
 BINARY := posta
 BUILD_DIR := bin
 UI_DIR := web
+# Where `go build` picks the dashboard up for embedding (see internal/web).
+EMBED_UI_DIR := internal/web/dist
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 LDFLAGS := -X github.com/goposta/posta/internal/config.Version=$(VERSION) -X github.com/goposta/posta/internal/config.CommitID=$(COMMIT)
 build:
 	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/posta
 
-build-ui:
+build-ui: ## Build the dashboard and stage it for embedding (internal/web/dist)
 	cd $(UI_DIR) && npm install && npm run build
+	# Stage the build output where //go:embed reads it, keeping the committed
+	# .gitkeep so `go build` still works on a clean tree.
+	rm -rf $(EMBED_UI_DIR)
+	cp -r $(UI_DIR)/dist $(EMBED_UI_DIR)
+	touch $(EMBED_UI_DIR)/.gitkeep
 
-build-all: build-ui build
+build-all: build-ui build ## Build the dashboard, then a self-contained binary
 
 run: build
 	./$(BUILD_DIR)/$(BINARY) server
@@ -58,6 +65,8 @@ fmt:
 
 clean:
 	rm -rf $(BUILD_DIR)
+	rm -rf $(EMBED_UI_DIR)
+	mkdir -p $(EMBED_UI_DIR) && touch $(EMBED_UI_DIR)/.gitkeep
 	rm -rf $(UI_DIR)/dist
 
 tidy:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,12 @@ RUN go mod download
 
 COPY cmd/ cmd/
 COPY internal/ internal/
+
+# Stage the built dashboard where //go:embed reads it, so the binary is
+# self-contained. Must come after `COPY internal/`, which would otherwise
+# clobber it.
+COPY --from=ui-builder /app/web/dist ./internal/web/dist
+
 RUN CGO_ENABLED=0 go build \
     -ldflags "-s -w -X 'github.com/goposta/posta/internal/config.Version=${VERSION}' -X 'github.com/goposta/posta/internal/config.CommitID=${COMMIT}' -X 'github.com/goposta/posta/internal/config.BuildDate=${BUILD_DATE}'" \
     -o /bin/posta ./cmd/posta
@@ -41,12 +47,10 @@ LABEL org.opencontainers.image.title="posta" \
 RUN apk add --no-cache ca-certificates tzdata \
     && addgroup -S posta && adduser -S posta -G posta
 
+# Single self-contained binary: the dashboard is embedded, so there are no
+# static files to copy and no POSTA_WEB_DIR to set.
 COPY --from=builder /bin/posta /bin/posta
 RUN ln -s /bin/posta /posta
-COPY --from=ui-builder /app/web/dist /app/web/dist
-
-ENV POSTA_WEB_DIR=/app/web/dist
-
 
 USER posta
 EXPOSE 9000

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,9 @@ type Config struct {
 	PlanEnforcement   bool
 	WorkspaceOnlyMode bool
 
+	// WebDir overrides where the dashboard is served from. The UI is normally
+	// embedded in the binary (internal/web); setting POSTA_WEB_DIR serves it from
+	// this directory instead, for frontend development or a customized build.
 	WebDir      string
 	AppWebURL   string
 	ApiBaseURL  string
@@ -248,7 +251,7 @@ func New() *Config {
 		MetricsEnabled:    goutils.EnvBool("POSTA_METRICS_ENABLED", false),
 		PlanEnforcement:   goutils.EnvBool("POSTA_PLAN_ENFORCEMENT", false),
 		WorkspaceOnlyMode: goutils.EnvBool("POSTA_WORKSPACE_ONLY_MODE", false),
-		WebDir:            goutils.Env("POSTA_WEB_DIR", "web/dist"),
+		WebDir:            goutils.Env("POSTA_WEB_DIR", ""),
 		AppWebURL:         goutils.Env("POSTA_WEB_URL", ""),
 		ApiBaseURL:        goutils.Env("POSTA_API_URL", ""),
 

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -48,6 +48,7 @@ import (
 	"github.com/goposta/posta/internal/services/workspacemigrate"
 	"github.com/goposta/posta/internal/storage/blob"
 	"github.com/goposta/posta/internal/storage/repositories"
+	"github.com/goposta/posta/internal/web"
 	"github.com/goposta/posta/internal/worker"
 	"github.com/hibiken/asynq"
 	"github.com/jkaninda/okapi"
@@ -482,7 +483,17 @@ func (r *Router) registerRoutes() {
 	// Documentation-only OpenAPI webhooks (events Posta POSTs to subscribers).
 	r.registerWebhookDocs()
 
-	// Dashboard UI (static files + SPA fallback)
-	r.app.SPA("/", r.cfg.WebDir, okapi.SPAConfig{MaxAge: time.Hour})
-
+	// Dashboard UI (static files + SPA fallback). Registered last so API routes
+	// win; Okapi auto-excludes their top-level segments (/api, /healthz, /metrics)
+	// from the index fallback, so those keep returning JSON rather than index.html.
+	//
+	// The UI is embedded in the binary (internal/web), so a stock `posta`
+	// executable serves it with no static files to ship. POSTA_WEB_DIR overrides
+	// this to serve from disk — useful for frontend development against live
+	// rebuilds, or to swap in a customized build without recompiling.
+	if r.cfg.WebDir != "" {
+		r.app.Web("/", r.cfg.WebDir, okapi.WebConfig{MaxAge: time.Hour})
+	} else {
+		r.app.WebFS("/", web.Assets, okapi.WebConfig{Root: "dist", MaxAge: time.Hour})
+	}
 }

--- a/internal/web/embed.go
+++ b/internal/web/embed.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Jonas Kaninda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package web embeds the built dashboard (the Vue SPA) into the Go binary so a
+// single `posta` executable serves both the API and the UI — no static files to
+// ship alongside it and no POSTA_WEB_DIR to configure.
+//
+// The `dist/` directory is a build artifact: `make build-ui` runs the Vue build
+// and stages its output here, then `go build` bakes it in. Only a placeholder
+// (.gitkeep) is committed, so `go build` and `go test` always compile on a clean
+// checkout; in that case the embedded FS holds no index.html and the UI routes
+// 404 while the API serves normally. Release and Docker builds always build the
+// UI first, so shipped binaries are self-contained.
+package web
+
+import "embed"
+
+// Assets holds the built SPA under a top-level "dist/" directory. It is served
+// through Okapi's WebFS with WebConfig{Root: "dist"}. The `all:` prefix keeps
+// dotted files (the .gitkeep placeholder, and any dotfiles Vite emits), which
+// //go:embed would otherwise skip.
+//
+//go:embed all:dist
+var Assets embed.FS


### PR DESCRIPTION
Bake the built Vue dashboard into the Go binary with //go:embed