### PR TITLE
feat(retention): split email body & attachment retention

### DIFF
--- a/docs/docs/admin/platform-settings.md
+++ b/docs/docs/admin/platform-settings.md
@@ -50,7 +50,9 @@ Keys prefixed with `app.` are reserved and cannot be modified.
 | `default_rate_limit_daily` | int | `1000` | Default daily send limit for new workspaces |
 | `max_batch_size` | int | `100` | Default max recipients per batch send |
 | `max_attachment_size_mb` | int | `10` | Default max attachment size in MB |
-| `retention_days` | int | `30` | Days to retain email logs |
+| `retention_days` | int | `30` | Days to retain email records (metadata). Upper bound for the content windows below |
+| `email_body_retention_days` | int | `retention_days` | Days to retain email body content (HTML/text). Capped at `retention_days` |
+| `email_attachment_retention_days` | int | `retention_days` | Days to retain attachments and raw inbound messages. Capped at `retention_days` |
 | `audit_log_retention_days` | int | `90` | Days to retain audit log entries |
 | `webhook_delivery_retention_days` | int | `30` | Days to retain webhook delivery history |
 | `global_bounce_threshold` | int | `5` | Platform-wide bounce rate threshold (percent) |
@@ -62,3 +64,55 @@ Keys prefixed with `app.` are reserved and cannot be modified.
 | `login_rate_limit_window_minutes` | int | `15` | Rate limit window duration in minutes |
 | `email_content_visibility` | bool | `false` | Show full email content (body/HTML) in logs and detail views |
 | `custom_headers_enabled` | bool | `false` | Allow workspaces to add custom email headers |
+
+### Email retention layers
+
+Email data has two very different cost profiles. The **record** — subject, sender,
+recipients, status, timestamps — is tiny and worth keeping around for a searchable
+history. The **content** — HTML/text bodies, attachments, and (for inbound mail) the raw
+`.eml` — is what actually fills the disk. Posta retains them on independent schedules, so
+you can keep a long, lightweight log while purging bulk content much sooner.
+
+Three windows apply to every email, all measured from its creation time:
+
+| Layer | Setting | What it removes | What survives |
+|-------|---------|-----------------|---------------|
+| Record | `retention_days` | the whole row — metadata **and** content | nothing |
+| Body | `email_body_retention_days` | HTML + text body | the record (metadata) |
+| Attachments | `email_attachment_retention_days` | attachments + their stored bytes | the record (metadata) |
+
+The body and attachment layers **scrub** content in place: the row stays, so the email
+still appears in dashboard lists and detail views with its metadata intact — only the
+body/attachment fields come back empty. Only the record layer removes the row entirely.
+
+#### Example
+
+With `retention_days = 180`, `email_body_retention_days = 30`, and
+`email_attachment_retention_days = 30`:
+
+- **Day 0–30** — full email: metadata, body, and attachments.
+- **Day 31–180** — metadata only: body and attachments are gone, but the email still
+  shows up in the log with its subject, sender, and status.
+- **Day 181+** — the record itself is deleted.
+
+#### Rules
+
+- **Defaults & upgrades.** Both content windows default to the current value of
+  `retention_days`, so a fresh install — and any upgrade of an existing one — behaves
+  exactly as before (everything purged together) until an admin deliberately shortens a
+  content window.
+- **Upper bound.** Content windows are **capped at `retention_days`**: a larger value has
+  no effect, because the row and all its content are deleted first. The dashboard clamps
+  the inputs to `retention_days`, and the cleanup job enforces the same cap server-side.
+- **Body and attachments are independent.** Either may be kept longer or shorter than the
+  other. The one coupling is the inbound raw `.eml`, which contains *both*: it is purged
+  at the **shorter** of the two windows, so it can never preserve content past either
+  type's own retention.
+- **Not the same as redaction.** [`email_content_visibility`](#available-settings) only
+  *hides* body content from the dashboard and API responses — the data is still stored at
+  rest. The retention windows above actually *delete* it from the database and blob
+  storage. Use visibility for day-to-day privacy in the UI, and the content windows to
+  reduce what is stored on disk.
+
+The retention cleanup job runs once daily at 03:00 UTC, so content is purged within
+roughly 24 hours of crossing a window.

--- a/docs/docs/gdpr/data-deletion.md
+++ b/docs/docs/gdpr/data-deletion.md
@@ -135,8 +135,13 @@ curl -X POST http://localhost:9000/api/v1/workspaces/current/gdpr/delete-email-l
 
 Administrators can configure automatic data retention via [Platform Settings](/docs/admin/platform-settings):
 
-- `email_retention_days` — Auto-delete email logs after N days
-- `webhook_retention_days` — Auto-delete webhook delivery history after N days
+- `retention_days` — Auto-delete email records after N days
+- `email_body_retention_days` — Scrub email body content after N days (record kept)
+- `email_attachment_retention_days` — Scrub attachments and raw inbound messages after N days (record kept)
+- `webhook_delivery_retention_days` — Auto-delete webhook delivery history after N days
 - `audit_log_retention_days` — Auto-delete audit log entries after N days
 
-The retention cleanup job runs daily at 2:00 AM.
+The body/attachment windows let you purge heavy content early while keeping a lightweight
+log; see [Email retention layers](/docs/admin/platform-settings#email-retention-layers).
+
+The retention cleanup job runs daily at 03:00 UTC.

--- a/internal/cron/jobs/retention.go
+++ b/internal/cron/jobs/retention.go
@@ -31,7 +31,8 @@ import (
 )
 
 // RetentionCleanupJob purges old email logs, audit events, and webhook
-// delivery records based on platform retention settings.
+// delivery records based on platform retention settings. It also scrubs email
+// bodies and attachments off records that outlive their (shorter) content windows.
 type RetentionCleanupJob struct {
 	emailRepo        *repositories.EmailRepository
 	eventRepo        *repositories.EventRepository
@@ -153,6 +154,32 @@ func (j *RetentionCleanupJob) deleteRawKeys(keys []string) int {
 func (j *RetentionCleanupJob) Name() string     { return "retention-cleanup" }
 func (j *RetentionCleanupJob) Schedule() string { return "0 3 * * *" } // daily at 03:00 UTC
 
+// capDays caps a content window at the record window. A value of 0 means "keep
+// forever" on either side, so it is never treated as a cap or capped.
+func capDays(v, limit int) int {
+	if limit <= 0 || v <= 0 {
+		return v
+	}
+	if v > limit {
+		return limit
+	}
+	return v
+}
+
+// minDays returns the shorter of two windows, treating 0 ("forever") as no bound.
+func minDays(a, b int) int {
+	if a <= 0 {
+		return b
+	}
+	if b <= 0 {
+		return a
+	}
+	if a < b {
+		return a
+	}
+	return b
+}
+
 func (j *RetentionCleanupJob) Run(_ context.Context, _ *asynq.Client) error {
 	// Clean up email logs (and any blob-stored attachments).
 	emailRetention := j.settings.RetentionDays()
@@ -198,6 +225,82 @@ func (j *RetentionCleanupJob) Run(_ context.Context, _ *asynq.Client) error {
 			} else if deleted > 0 {
 				logger.Info("retention cleanup: deleted old inbound emails", "count", deleted, "older_than_days", emailRetention)
 			}
+		}
+	}
+
+	// Content windows can never usefully exceed the record window — the row (and
+	// all its content) is deleted first — so cap them at the email log retention.
+	bodyRetention := capDays(j.settings.EmailBodyRetentionDays(), emailRetention)
+	attachmentRetention := capDays(j.settings.EmailAttachmentRetentionDays(), emailRetention)
+
+	// Scrub attachments off records that outlive the attachment window (keeps the row).
+	if attachmentRetention > 0 {
+		before := time.Now().AddDate(0, 0, -attachmentRetention)
+
+		if j.blobStore != nil {
+			if jsons, err := j.emailRepo.AttachmentsJSONOlderThan(before); err == nil {
+				j.deleteOutboundAttachmentBlobs(jsons)
+			} else {
+				logger.Error("retention cleanup: failed to enumerate outbound attachments for scrub", "error", err)
+			}
+		}
+		if scrubbed, err := j.emailRepo.ScrubAttachmentsOlderThan(before); err != nil {
+			logger.Error("retention cleanup: failed to scrub outbound attachments", "error", err)
+		} else if scrubbed > 0 {
+			logger.Info("retention cleanup: scrubbed outbound attachments", "count", scrubbed, "older_than_days", attachmentRetention)
+		}
+
+		if j.inboundEmailRepo != nil {
+			if j.blobStore != nil {
+				if jsons, _, err := j.inboundEmailRepo.InboundBlobKeysOlderThan(before); err == nil {
+					j.deleteInboundAttachmentBlobs(jsons)
+				} else {
+					logger.Error("retention cleanup: failed to enumerate inbound attachments for scrub", "error", err)
+				}
+			}
+			if scrubbed, err := j.inboundEmailRepo.ScrubAttachmentsOlderThan(before); err != nil {
+				logger.Error("retention cleanup: failed to scrub inbound attachments", "error", err)
+			} else if scrubbed > 0 {
+				logger.Info("retention cleanup: scrubbed inbound attachments", "count", scrubbed, "older_than_days", attachmentRetention)
+			}
+		}
+	}
+
+	// Scrub bodies off records that outlive the body window (keeps the row).
+	if bodyRetention > 0 {
+		before := time.Now().AddDate(0, 0, -bodyRetention)
+
+		if scrubbed, err := j.emailRepo.ScrubBodiesOlderThan(before); err != nil {
+			logger.Error("retention cleanup: failed to scrub outbound bodies", "error", err)
+		} else if scrubbed > 0 {
+			logger.Info("retention cleanup: scrubbed outbound bodies", "count", scrubbed, "older_than_days", bodyRetention)
+		}
+
+		if j.inboundEmailRepo != nil {
+			if scrubbed, err := j.inboundEmailRepo.ScrubBodiesOlderThan(before); err != nil {
+				logger.Error("retention cleanup: failed to scrub inbound bodies", "error", err)
+			} else if scrubbed > 0 {
+				logger.Info("retention cleanup: scrubbed inbound bodies", "count", scrubbed, "older_than_days", bodyRetention)
+			}
+		}
+	}
+
+	// The raw .eml holds both body and attachments, so purge it at the shorter of
+	// the two windows — it must never outlive either content type.
+	if rawRetention := minDays(bodyRetention, attachmentRetention); rawRetention > 0 && j.inboundEmailRepo != nil {
+		before := time.Now().AddDate(0, 0, -rawRetention)
+
+		if j.blobStore != nil {
+			if _, rawKeys, err := j.inboundEmailRepo.InboundBlobKeysOlderThan(before); err == nil {
+				j.deleteRawKeys(rawKeys)
+			} else {
+				logger.Error("retention cleanup: failed to enumerate inbound raw blobs for scrub", "error", err)
+			}
+		}
+		if scrubbed, err := j.inboundEmailRepo.ScrubRawOlderThan(before); err != nil {
+			logger.Error("retention cleanup: failed to scrub inbound raw messages", "error", err)
+		} else if scrubbed > 0 {
+			logger.Info("retention cleanup: scrubbed inbound raw messages", "count", scrubbed, "older_than_days", rawRetention)
 		}
 	}
 

--- a/internal/cron/jobs/retention_test.go
+++ b/internal/cron/jobs/retention_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Jonas Kaninda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package jobs
+
+import "testing"
+
+// capDays encodes "content never outlives the record": a positive window is
+// clamped to the record window; 0 ("forever") is never capped or used as a cap.
+func TestCapDays(t *testing.T) {
+	cases := []struct {
+		v, limit, want int
+	}{
+		{v: 30, limit: 180, want: 30},   // below the cap
+		{v: 180, limit: 180, want: 180}, // at the cap
+		{v: 999, limit: 180, want: 180}, // above the cap → clamped
+		{v: 0, limit: 180, want: 0},     // v = forever → not capped
+		{v: 30, limit: 0, want: 30},     // record = forever → no cap
+		{v: 0, limit: 0, want: 0},       // both forever
+	}
+	for _, c := range cases {
+		if got := capDays(c.v, c.limit); got != c.want {
+			t.Errorf("capDays(%d, %d) = %d, want %d", c.v, c.limit, got, c.want)
+		}
+	}
+}
+
+// minDays encodes "raw .eml never outlives either content window": the shorter
+// finite window wins, and 0 ("forever") means no bound on that side.
+func TestMinDays(t *testing.T) {
+	cases := []struct {
+		a, b, want int
+	}{
+		{a: 30, b: 90, want: 30}, // shorter first
+		{a: 90, b: 30, want: 30}, // shorter second
+		{a: 30, b: 30, want: 30}, // equal
+		{a: 0, b: 30, want: 30},  // a forever → b bounds
+		{a: 30, b: 0, want: 30},  // b forever → a bounds
+		{a: 0, b: 0, want: 0},    // both forever
+	}
+	for _, c := range cases {
+		if got := minDays(c.a, c.b); got != c.want {
+			t.Errorf("minDays(%d, %d) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/internal/services/seeder/settings.go
+++ b/internal/services/seeder/settings.go
@@ -25,6 +25,13 @@ import (
 
 // SeedDefaultSettings creates default platform settings if they don't already exist.
 func SeedDefaultSettings(repo *repositories.SettingRepository) {
+	// Content-retention windows default to the record retention so that an upgrade
+	// never starts scrubbing content earlier than emails were already kept.
+	retentionDays := "30"
+	if s, err := repo.FindByKey("retention_days"); err == nil && s.Value != "" {
+		retentionDays = s.Value
+	}
+
 	defaults := []models.Setting{
 		{Key: "registration_enabled", Value: "false", Type: "bool"},
 		{Key: "require_email_verification", Value: "true", Type: "bool"},
@@ -34,6 +41,8 @@ func SeedDefaultSettings(repo *repositories.SettingRepository) {
 		{Key: "max_batch_size", Value: "100", Type: "int"},
 		{Key: "max_attachment_size_mb", Value: "10", Type: "int"},
 		{Key: "retention_days", Value: "30", Type: "int"},
+		{Key: "email_body_retention_days", Value: retentionDays, Type: "int"},
+		{Key: "email_attachment_retention_days", Value: retentionDays, Type: "int"},
 		{Key: "global_bounce_threshold", Value: "5", Type: "int"},
 		{Key: "smtp_timeout_seconds", Value: "30", Type: "int"},
 		{Key: "maintenance_mode", Value: "false", Type: "bool"},

--- a/internal/services/settings/provider.go
+++ b/internal/services/settings/provider.go
@@ -127,7 +127,16 @@ func (p *Provider) MaxAttachmentSizeMB() int    { return p.GetInt("max_attachmen
 func (p *Provider) GlobalBounceThreshold() int  { return p.GetInt("global_bounce_threshold", 5) }
 func (p *Provider) SMTPTimeoutSeconds() int     { return p.GetInt("smtp_timeout_seconds", 30) }
 func (p *Provider) RetentionDays() int          { return p.GetInt("retention_days", 30) }
-func (p *Provider) AuditLogRetentionDays() int  { return p.GetInt("audit_log_retention_days", 90) }
+
+// EmailBodyRetentionDays / EmailAttachmentRetentionDays default to the record
+// retention so content is purged with the row unless an admin sets a shorter window.
+func (p *Provider) EmailBodyRetentionDays() int {
+	return p.GetInt("email_body_retention_days", p.RetentionDays())
+}
+func (p *Provider) EmailAttachmentRetentionDays() int {
+	return p.GetInt("email_attachment_retention_days", p.RetentionDays())
+}
+func (p *Provider) AuditLogRetentionDays() int { return p.GetInt("audit_log_retention_days", 90) }
 func (p *Provider) WebhookDeliveryRetentionDays() int {
 	return p.GetInt("webhook_delivery_retention_days", 30)
 }

--- a/internal/storage/repositories/email_repo.go
+++ b/internal/storage/repositories/email_repo.go
@@ -162,3 +162,21 @@ func (r *EmailRepository) AttachmentsJSONOlderThan(before time.Time) ([]string, 
 		Pluck("attachments_json", &out).Error
 	return out, err
 }
+
+// ScrubBodiesOlderThan clears HTML/text bodies of emails older than the cutoff,
+// keeping the record. Returns the number of rows scrubbed.
+func (r *EmailRepository) ScrubBodiesOlderThan(before time.Time) (int64, error) {
+	result := r.db.Model(&models.Email{}).
+		Where("created_at < ? AND (html_body <> '' OR text_body <> '')", before).
+		Updates(map[string]interface{}{"html_body": "", "text_body": ""})
+	return result.RowsAffected, result.Error
+}
+
+// ScrubAttachmentsOlderThan clears attachment metadata of emails older than the
+// cutoff, keeping the record. Blobs are deleted separately by the caller.
+func (r *EmailRepository) ScrubAttachmentsOlderThan(before time.Time) (int64, error) {
+	result := r.db.Model(&models.Email{}).
+		Where("created_at < ? AND attachments_json <> ''", before).
+		Update("attachments_json", "")
+	return result.RowsAffected, result.Error
+}

--- a/internal/storage/repositories/email_scrub_test.go
+++ b/internal/storage/repositories/email_scrub_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Jonas Kaninda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package repositories
+
+import (
+	"testing"
+	"time"
+
+	"github.com/goposta/posta/internal/models"
+	"github.com/lib/pq"
+)
+
+func TestScrubOlderThan_ClearsContentKeepsMetadata(t *testing.T) {
+	db := testDB(t)
+	if err := db.AutoMigrate(&models.Email{}); err != nil {
+		t.Skipf("skipping: cannot migrate email schema: %v", err)
+	}
+
+	tx := db.Begin()
+	t.Cleanup(func() { tx.Rollback() })
+
+	userID := createUser(t, tx, "scrub@test.local")
+	repo := NewEmailRepository(tx)
+
+	old := &models.Email{
+		UserID:          userID,
+		Sender:          "from@test.local",
+		Recipients:      pq.StringArray{"to@test.local"},
+		Subject:         "keep me",
+		HTMLBody:        "<p>secret</p>",
+		TextBody:        "secret",
+		AttachmentsJSON: `[{"filename":"a.pdf"}]`,
+		Status:          models.EmailStatusSent,
+		CreatedAt:       time.Now().AddDate(0, 0, -60),
+	}
+	recent := &models.Email{
+		UserID:     userID,
+		Sender:     "from@test.local",
+		Recipients: pq.StringArray{"to@test.local"},
+		Subject:    "recent",
+		HTMLBody:   "<p>fresh</p>",
+		TextBody:   "fresh",
+		Status:     models.EmailStatusSent,
+		CreatedAt:  time.Now(),
+	}
+	if err := repo.Create(old); err != nil {
+		t.Fatalf("create old: %v", err)
+	}
+	if err := repo.Create(recent); err != nil {
+		t.Fatalf("create recent: %v", err)
+	}
+
+	cutoff := time.Now().AddDate(0, 0, -30)
+	if n, err := repo.ScrubBodiesOlderThan(cutoff); err != nil || n != 1 {
+		t.Fatalf("ScrubBodiesOlderThan: n=%d err=%v (want 1, nil)", n, err)
+	}
+	if n, err := repo.ScrubAttachmentsOlderThan(cutoff); err != nil || n != 1 {
+		t.Fatalf("ScrubAttachmentsOlderThan: n=%d err=%v (want 1, nil)", n, err)
+	}
+
+	gotOld, err := repo.FindByID(old.ID)
+	if err != nil {
+		t.Fatalf("reload old: %v", err)
+	}
+	if gotOld.HTMLBody != "" || gotOld.TextBody != "" || gotOld.AttachmentsJSON != "" {
+		t.Fatalf("old content not scrubbed: html=%q text=%q att=%q", gotOld.HTMLBody, gotOld.TextBody, gotOld.AttachmentsJSON)
+	}
+	if gotOld.Subject != "keep me" || gotOld.Sender != "from@test.local" {
+		t.Fatalf("old metadata altered: subject=%q sender=%q", gotOld.Subject, gotOld.Sender)
+	}
+
+	gotRecent, err := repo.FindByID(recent.ID)
+	if err != nil {
+		t.Fatalf("reload recent: %v", err)
+	}
+	if gotRecent.HTMLBody == "" || gotRecent.TextBody == "" {
+		t.Fatalf("recent content should be untouched, got html=%q text=%q", gotRecent.HTMLBody, gotRecent.TextBody)
+	}
+}

--- a/internal/storage/repositories/inbound_email_repo.go
+++ b/internal/storage/repositories/inbound_email_repo.go
@@ -204,3 +204,31 @@ func (r *InboundEmailRepository) InboundBlobKeysOlderThan(before time.Time) (att
 		Pluck("raw_storage_key", &rawKeys).Error
 	return attachmentsJSON, rawKeys, err
 }
+
+// ScrubBodiesOlderThan clears bodies of inbound emails older than the cutoff,
+// keeping the record. The raw .eml is scrubbed separately (see ScrubRawOlderThan).
+func (r *InboundEmailRepository) ScrubBodiesOlderThan(before time.Time) (int64, error) {
+	result := r.db.Model(&models.InboundEmail{}).
+		Where("created_at < ? AND (html_body <> '' OR text_body <> '')", before).
+		Updates(map[string]interface{}{"html_body": "", "text_body": ""})
+	return result.RowsAffected, result.Error
+}
+
+// ScrubRawOlderThan clears the raw .eml reference of inbound emails older than
+// the cutoff. Because the raw message holds both body and attachments, it is
+// purged at the shorter of the two content windows. The blob is deleted separately.
+func (r *InboundEmailRepository) ScrubRawOlderThan(before time.Time) (int64, error) {
+	result := r.db.Model(&models.InboundEmail{}).
+		Where("created_at < ? AND raw_storage_key <> ''", before).
+		Update("raw_storage_key", "")
+	return result.RowsAffected, result.Error
+}
+
+// ScrubAttachmentsOlderThan clears attachment metadata of inbound emails older
+// than the cutoff, keeping the record. Blobs are deleted separately by the caller.
+func (r *InboundEmailRepository) ScrubAttachmentsOlderThan(before time.Time) (int64, error) {
+	result := r.db.Model(&models.InboundEmail{}).
+		Where("created_at < ? AND attachments_json <> ''", before).
+		Update("attachments_json", "")
+	return result.RowsAffected, result.Error
+}

--- a/internal/storage/repositories/inbound_email_scrub_test.go
+++ b/internal/storage/repositories/inbound_email_scrub_test.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Jonas Kaninda
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package repositories
+
+import (
+	"testing"
+	"time"
+
+	"github.com/goposta/posta/internal/models"
+	"github.com/lib/pq"
+	"gorm.io/gorm"
+)
+
+func reloadInbound(t *testing.T, tx *gorm.DB, id uint) *models.InboundEmail {
+	t.Helper()
+	var m models.InboundEmail
+	if err := tx.First(&m, id).Error; err != nil {
+		t.Fatalf("reload inbound %d: %v", id, err)
+	}
+	return &m
+}
+
+func TestInboundScrub_SeparatesBodyRawAndAttachments(t *testing.T) {
+	db := testDB(t)
+	if err := db.AutoMigrate(&models.Domain{}, &models.InboundEmail{}); err != nil {
+		t.Skipf("skipping: cannot migrate inbound schema: %v", err)
+	}
+
+	tx := db.Begin()
+	t.Cleanup(func() { tx.Rollback() })
+
+	userID := createUser(t, tx, "inbound-scrub@test.local")
+	domain := &models.Domain{UserID: userID, Domain: "scrub.test.local", VerificationToken: "tok"}
+	if err := tx.Create(domain).Error; err != nil {
+		t.Fatalf("create domain: %v", err)
+	}
+
+	repo := NewInboundEmailRepository(tx)
+	old := &models.InboundEmail{
+		UserID:          userID,
+		DomainID:        domain.ID,
+		Sender:          "from@scrub.test.local",
+		Recipients:      pq.StringArray{"to@scrub.test.local"},
+		Subject:         "keep me",
+		TextBody:        "secret",
+		HTMLBody:        "<p>secret</p>",
+		AttachmentsJSON: `[{"filename":"a.pdf"}]`,
+		RawStorageKey:   "raw/old.eml",
+		Source:          models.InboundSourceSMTP,
+		ReceivedAt:      time.Now().AddDate(0, 0, -60),
+		CreatedAt:       time.Now().AddDate(0, 0, -60),
+	}
+	if err := tx.Create(old).Error; err != nil {
+		t.Fatalf("create inbound: %v", err)
+	}
+
+	cutoff := time.Now().AddDate(0, 0, -30)
+
+	// Body scrub must clear bodies but leave raw and attachments intact.
+	if n, err := repo.ScrubBodiesOlderThan(cutoff); err != nil || n != 1 {
+		t.Fatalf("ScrubBodiesOlderThan: n=%d err=%v (want 1, nil)", n, err)
+	}
+	got := reloadInbound(t, tx, old.ID)
+	if got.HTMLBody != "" || got.TextBody != "" {
+		t.Fatalf("bodies not scrubbed: html=%q text=%q", got.HTMLBody, got.TextBody)
+	}
+	if got.RawStorageKey == "" || got.AttachmentsJSON == "" {
+		t.Fatalf("body scrub must not touch raw/attachments: raw=%q att=%q", got.RawStorageKey, got.AttachmentsJSON)
+	}
+	if got.Subject != "keep me" {
+		t.Fatalf("metadata altered: subject=%q", got.Subject)
+	}
+
+	// Attachment scrub clears attachments only.
+	if n, err := repo.ScrubAttachmentsOlderThan(cutoff); err != nil || n != 1 {
+		t.Fatalf("ScrubAttachmentsOlderThan: n=%d err=%v (want 1, nil)", n, err)
+	}
+	got = reloadInbound(t, tx, old.ID)
+	if got.AttachmentsJSON != "" || got.RawStorageKey == "" {
+		t.Fatalf("attachment scrub wrong: att=%q raw=%q", got.AttachmentsJSON, got.RawStorageKey)
+	}
+
+	// Raw scrub clears the raw .eml reference.
+	if n, err := repo.ScrubRawOlderThan(cutoff); err != nil || n != 1 {
+		t.Fatalf("ScrubRawOlderThan: n=%d err=%v (want 1, nil)", n, err)
+	}
+	if got = reloadInbound(t, tx, old.ID); got.RawStorageKey != "" {
+		t.Fatalf("raw not scrubbed: raw=%q", got.RawStorageKey)
+	}
+}

--- a/web/src/views/admin/Settings.vue
+++ b/web/src/views/admin/Settings.vue
@@ -11,7 +11,7 @@ const loading = ref(true)
 const settings = ref<AdminSetting[]>([])
 
 // Human-readable labels and descriptions for each setting key
-const settingMeta: Record<string, { label: string; description: string; category: string }> = {
+const settingMeta: Record<string, { label: string; description: string; category: string; advanced?: boolean }> = {
   registration_enabled: { label: 'User Registration', description: 'Allow new users to self-register.', category: 'General' },
   allowed_signup_domains: { label: 'Allowed Signup Domains', description: 'Restrict registration to specific email domains (comma-separated). Leave empty to allow all.', category: 'General' },
   maintenance_mode: { label: 'Maintenance Mode', description: 'Disable all email sending and show a maintenance banner.', category: 'General' },
@@ -27,7 +27,9 @@ const settingMeta: Record<string, { label: string; description: string; category
   login_rate_limit_count: { label: 'Login Rate Limit (attempts)', description: 'Max login attempts per IP within the login window.', category: 'Security' },
   login_rate_limit_window_minutes: { label: 'Login Rate Limit Window (minutes)', description: 'Time window for the login rate limit.', category: 'Security' },
   smtp_timeout_seconds: { label: 'SMTP Timeout (seconds)', description: 'Global SMTP connection timeout.', category: 'Limits' },
-  retention_days: { label: 'Email Log Retention (days)', description: 'How long to keep email logs before cleanup.', category: 'Retention' },
+  retention_days: { label: 'Email Log Retention (days)', description: 'How long to keep email records (metadata) before they are fully removed.', category: 'Retention' },
+  email_body_retention_days: { label: 'Email Body Retention (days)', description: 'How long to keep email body content (HTML/Text). Should be ≤ log retention.', category: 'Retention', advanced: true },
+  email_attachment_retention_days: { label: 'Attachment Retention (days)', description: 'How long to keep attachments and raw messages. Should be ≤ log retention.', category: 'Retention', advanced: true },
   audit_log_retention_days: { label: 'Audit Log Retention (days)', description: 'How long to keep audit/event logs.', category: 'Retention' },
   webhook_delivery_retention_days: { label: 'Webhook Delivery Retention (days)', description: 'How long to keep webhook delivery logs.', category: 'Retention' },
   email_content_visibility: { label: 'Email Content Visibility', description: 'When enabled, email body content (HTML/Text) is visible in the dashboard. When disabled, content is redacted for privacy.', category: 'Privacy' },
@@ -39,9 +41,39 @@ const categories = ['General', 'Security', 'Privacy', 'Limits', 'Retention']
 function settingsByCategory(category: string) {
   // Only render known, documented settings. Unknown keys (e.g. the upgrade
   // framework's internal app.* bookkeeping rows) are never editable platform
-  // settings and must not leak into the UI.
-  return settings.value.filter(s => settingMeta[s.key]?.category === category)
+  // settings and must not leak into the UI. Advanced keys are rendered
+  // separately inside their own collapsible block.
+  return settings.value.filter(s => settingMeta[s.key]?.category === category && !settingMeta[s.key]?.advanced)
 }
+
+// Granular content-retention fields live under a spoiler beneath Email Log
+// Retention. It stays open whenever any content window differs from the record
+// window, so an active split is always visible.
+const advancedRetentionKeys = ['email_body_retention_days', 'email_attachment_retention_days']
+const contentRetentionOpen = ref(false)
+
+function currentValue(key: string): string {
+  const s = settings.value.find(x => x.key === key)
+  return getEditedValue(key, s?.value ?? '')
+}
+
+const advancedRetentionSettings = computed(() =>
+  advancedRetentionKeys
+    .map(k => settings.value.find(s => s.key === k))
+    .filter((s): s is AdminSetting => !!s),
+)
+const retentionSplit = computed(() => {
+  const base = parseInt(currentValue('retention_days'), 10)
+  // A real split means a content window purges content *before* the record is
+  // deleted: a positive value shorter than the record window — or any positive
+  // value when records are kept forever (base <= 0). A value of 0 ("purge with
+  // the record") or one >= the record window (clamped) has no distinct effect.
+  return advancedRetentionSettings.value.some(s => {
+    const v = parseInt(currentValue(s.key), 10)
+    return v > 0 && (isNaN(base) || base <= 0 || v < base)
+  })
+})
+const contentRetentionExpanded = computed(() => retentionSplit.value || contentRetentionOpen.value)
 
 
 const editedValues = ref<Record<string, string>>({})
@@ -80,7 +112,19 @@ async function commit(key: string) {
   const setting = settings.value.find(s => s.key === key)
   if (!setting) return
 
-  const value = getEditedValue(key, setting.value)
+  let value = getEditedValue(key, setting.value)
+
+  // Content-retention windows may never exceed the record window — the row (and
+  // all its content) is removed first, so a larger value would have no effect.
+  if (advancedRetentionKeys.includes(key)) {
+    const logMax = parseInt(currentValue('retention_days'), 10)
+    const n = parseInt(value, 10)
+    if (!isNaN(logMax) && logMax > 0 && !isNaN(n) && n > logMax) {
+      value = String(logMax)
+      editedValues.value[key] = value
+    }
+  }
+
   if (value === setting.value) {
     delete editedValues.value[key]
     return
@@ -94,6 +138,9 @@ async function commit(key: string) {
     setting.value = updated ? updated.value : value
     delete editedValues.value[key]
     flashSaved(key)
+    // Lowering the record window pulls any content window that now exceeds it
+    // back down, so the UI matches what the server (capDays) already enforces.
+    if (key === 'retention_days') clampAdvancedToLog()
   } catch {
     const label = settingMeta[key]?.label || key
     notify.error(`Failed to save “${label}”`)
@@ -110,6 +157,20 @@ function flashSaved(key: string) {
   savedFlashTimers[key] = setTimeout(() => {
     savedKeys.value[key] = false
   }, 2000)
+}
+
+// Clamp any content window that exceeds the (just-lowered) record window and
+// persist it, keeping the UI consistent with the server-side cap.
+function clampAdvancedToLog() {
+  const logMax = parseInt(currentValue('retention_days'), 10)
+  if (isNaN(logMax) || logMax <= 0) return
+  for (const key of advancedRetentionKeys) {
+    const n = parseInt(currentValue(key), 10)
+    if (!isNaN(n) && n > logMax) {
+      setEditedValue(key, String(logMax))
+      commit(key)
+    }
+  }
 }
 
 // Free-text / number input: track the value and debounce the save.
@@ -228,11 +289,11 @@ async function toggleBool(setting: AdminSetting) {
       <div v-for="category in categories" :key="category" class="card">
         <div class="card-header"><h2>{{ category }}</h2></div>
         <div class="card-body">
-          <div
+          <template
             v-for="setting in settingsByCategory(category)"
             :key="setting.key"
-            class="setting-row"
           >
+          <div class="setting-row">
             <div class="setting-info">
               <label class="setting-label">{{ settingMeta[setting.key]?.label || setting.key }}</label>
               <span class="setting-description">{{ settingMeta[setting.key]?.description || '' }}</span>
@@ -276,6 +337,52 @@ async function toggleBool(setting: AdminSetting) {
               </template>
             </div>
           </div>
+
+          <!-- Collapsible per-content-type retention, nested under Email Log Retention -->
+          <div
+            v-if="setting.key === 'retention_days' && advancedRetentionSettings.length"
+            class="content-retention"
+          >
+            <button
+              type="button"
+              class="content-retention-toggle"
+              :aria-expanded="contentRetentionExpanded"
+              @click="contentRetentionOpen = !contentRetentionOpen"
+            >
+              <span class="chevron" :class="{ open: contentRetentionExpanded }">▸</span>
+              <span>Detailed content retention</span>
+              <span v-if="retentionSplit" class="content-retention-badge">split</span>
+            </button>
+            <div v-show="contentRetentionExpanded" class="content-retention-body">
+              <div
+                v-for="adv in advancedRetentionSettings"
+                :key="adv.key"
+                class="setting-row"
+              >
+                <div class="setting-info">
+                  <label class="setting-label">{{ settingMeta[adv.key]?.label || adv.key }}</label>
+                  <span class="setting-description">{{ settingMeta[adv.key]?.description || '' }}</span>
+                </div>
+                <div class="setting-control">
+                  <span class="setting-status" aria-live="polite">
+                    <span v-if="savingKeys[adv.key]" class="setting-status-saving">Saving…</span>
+                    <span v-else-if="savedKeys[adv.key]" class="setting-status-saved">Saved ✓</span>
+                  </span>
+                  <input
+                    type="number"
+                    class="form-input setting-input-number"
+                    min="0"
+                    :max="currentValue('retention_days')"
+                    :value="getEditedValue(adv.key, adv.value)"
+                    @input="onInput(adv.key, $event)"
+                    @blur="commit(adv.key)"
+                    @keyup.enter="commit(adv.key)"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          </template>
           <div v-if="settingsByCategory(category).length === 0" class="empty-state">
             <p>No settings in this category.</p>
           </div>
@@ -329,6 +436,55 @@ async function toggleBool(setting: AdminSetting) {
   display: flex;
   align-items: center;
   gap: 10px;
+}
+
+/* Collapsible content-retention block, nested under Email Log Retention */
+.content-retention {
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.content-retention-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.content-retention-toggle:hover {
+  color: var(--text-primary);
+}
+
+.content-retention-toggle .chevron {
+  transition: transform 0.15s ease;
+  font-size: 11px;
+}
+
+.content-retention-toggle .chevron.open {
+  transform: rotate(90deg);
+}
+
+.content-retention-badge {
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent-primary, #8b5cf6);
+  background: color-mix(in srgb, var(--accent-primary, #8b5cf6) 18%, transparent);
+}
+
+.content-retention-body {
+  padding-left: 18px;
+}
+
+.content-retention-body .setting-row:last-child {
+  border-bottom: none;
 }
 
 /* Header auto-save status */


### PR DESCRIPTION
Optional split for retention — keep the email log longer, purge body/attachments sooner. Two new settings, default = capped at `retention_days`


<img width="1250" height="658" alt="telegram-cloud-photo-size-2-5406839591005788317-y" src="https://github.com/user-attachments/assets/34c9c23c-0268-49d7-a1b0-bdc3c188a0a3" />

<img width="1250" height="881" alt="telegram-cloud-photo-size-2-5406839591005788318-y" src="https://github.com/user-attachments/assets/9402bd68-e5e0-40c8-8a76-5ceca57cea16" />

<img width="1250" height="876" alt="telegram-cloud-photo-size-2-5406839591005788319-y" src="https://github.com/user-attachments/assets/6c34fa75-688d-45a1-be5d-2d8fed6f428a" />

