### PR TITLE
Document the official .NET SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Posta includes a web dashboard for managing templates, SMTP servers, domains, co
 * Go: [https://github.com/goposta/posta-go](https://github.com/goposta/posta-go)
 * PHP: [https://github.com/goposta/posta-php](https://github.com/goposta/posta-php)
 * Java: [https://github.com/goposta/posta-java](https://github.com/goposta/posta-java)
+* .NET: [https://github.com/goposta/posta-dotnet](https://github.com/goposta/posta-dotnet)
 
 ### Go Example
 
@@ -321,4 +322,3 @@ Apache License 2.0
 ## Copyright
 
 Copyright (c) 2026 Jonas Kaninda
-

--- a/docs/docs/getting-started/introduction.md
+++ b/docs/docs/getting-started/introduction.md
@@ -11,7 +11,7 @@ description: What is Posta and why use it
 ## Why Posta?
 
 - **Self-hosted** — Your data stays on your servers. No vendor lock-in.
-- **Developer-first** — Clean REST API with official SDKs for Go, PHP, and Java.
+- **Developer-first** — Clean REST API with official SDKs for Go, PHP, Java, and .NET.
 - **Full-featured** — Templates with versioning and localization, SMTP management, domain verification, webhooks, analytics, and more.
 - **Open source** — Licensed under Apache 2.0. Contribute, fork, or customize as needed.
 

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -147,6 +147,25 @@ SendResponse response = client.sendEmail(new SendEmailRequest()
 ```
 
 </TabItem>
+<TabItem value="dotnet" label=".NET">
+
+```csharp
+using Posta.Clients;
+using Posta.Models.Emails;
+
+using var client = new PostaClient("http://localhost:9000", "your-api-key");
+
+SendAnEmailResponse? response = await client.Emails.SendAnEmailAsync(
+    new SendAnEmailRequest
+    {
+        From = "sender@yourdomain.com",
+        To = ["recipient@example.com"],
+        Subject = "Hello from Posta!",
+        Html = "<h1>Welcome!</h1>"
+    });
+```
+
+</TabItem>
 </Tabs>
 
 ## Next Steps

--- a/docs/docs/sdks/dotnet.md
+++ b/docs/docs/sdks/dotnet.md
@@ -1,0 +1,83 @@
+---
+sidebar_position: 5
+title: .NET
+description: Posta .NET SDK
+---
+
+# .NET SDK
+
+Official typed .NET client for Posta.
+
+## Installation
+
+```shell
+dotnet add package Posta
+```
+
+**Requires:** .NET 10+
+
+## Quick Start
+
+```csharp
+using Posta.Clients;
+using Posta.Models.Emails;
+
+using var client = new PostaClient(
+    "https://posta.example.com",
+    "your-api-key");
+
+SendAnEmailResponse? response = await client.Emails.SendAnEmailAsync(
+    new SendAnEmailRequest
+    {
+        From = "Acme <hello@example.com>",
+        To = ["user@example.com"],
+        Subject = "Hello from Posta",
+        Html = "<h1>Hello!</h1>"
+    });
+```
+
+The client also provides typed API clients for templates, campaigns, subscribers,
+webhooks, workspaces, administration, and the other Posta API areas.
+
+## Aspire Integration
+
+For applications using .NET Aspire, install the client integration package:
+
+```shell
+dotnet add package Posta.Aspire
+```
+
+Register the client using the Posta resource name from your AppHost:
+
+```csharp
+builder.AddPostaClient("posta", settings =>
+{
+    settings.ApiKey = builder.Configuration["Posta:ApiKey"];
+});
+```
+
+Posta also has an official hosting integration in the
+[Aspire Community Toolkit](https://github.com/CommunityToolkit/Aspire/tree/main/src/CommunityToolkit.Aspire.Hosting.Posta).
+
+## Error Handling
+
+Non-successful HTTP responses throw `PostaApiException`, which exposes the HTTP
+status code, response body, and structured Posta error details.
+
+```csharp
+using Posta.Transport;
+
+try
+{
+    await client.Emails.GetEmailDetailsAsync(
+        new GetEmailDetailsRequest { Id = emailId });
+}
+catch (PostaApiException exception)
+{
+    Console.WriteLine(exception.StatusCode);
+    Console.WriteLine(exception.Error?.Message);
+}
+```
+
+See the [Posta .NET SDK repository](https://github.com/goposta/posta-dotnet) for
+complete configuration, Aspire, and API coverage documentation.

--- a/docs/docs/sdks/overview.md
+++ b/docs/docs/sdks/overview.md
@@ -6,7 +6,7 @@ description: Official Posta SDKs
 
 # Official SDKs
 
-Posta provides official client libraries for three languages. All SDKs offer the same core functionality:
+Posta provides official client libraries for four languages. All SDKs offer the same core functionality:
 
 | Method | Description |
 |--------|-------------|
@@ -22,6 +22,7 @@ Posta provides official client libraries for three languages. All SDKs offer the
 | [Go](/docs/sdks/go) | `github.com/goposta/posta-go` | Go 1.25+ |
 | [PHP](/docs/sdks/php) | `goposta/posta-php` | PHP 8.1+ |
 | [Java](/docs/sdks/java) | `com.github.goposta:posta-java` | Java 11+ |
+| [.NET](/docs/sdks/dotnet) | `Posta` | .NET 10+ |
 
 ## Error Handling
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -167,6 +167,7 @@ const sidebars: SidebarsConfig = {
         'sdks/go',
         'sdks/php',
         'sdks/java',
+        'sdks/dotnet',
       ],
     },
   ],

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -70,7 +70,7 @@ function HomepageHeader() {
         <div className={styles.stats}>
           {[
             {value: 'API-First', label: 'Architecture'},
-            {value: '3 SDKs', label: 'Go · PHP · Java'},
+            {value: '4 SDKs', label: 'Go · PHP · Java · .NET'},
             {value: 'In & Outbound', label: 'SMTP Delivery'},
             {value: 'GDPR', label: 'Compliant'},
           ].map((stat) => (


### PR DESCRIPTION
## What changed

- add the official .NET SDK to the root README and SDK overview
- add a dedicated .NET SDK guide with installation, typed-client usage, error handling, and Aspire integration
- include .NET in the documentation quickstart, sidebar, introduction, and homepage SDK count

## Why

The official `goposta/posta-dotnet` SDK and Posta integration for the Aspire Community Toolkit are now available, but the main Posta documentation only listed Go, PHP, and Java.

## Impact

.NET developers can now discover the supported NuGet packages, copy a working email example, and find the Aspire integration directly from the Posta documentation.

## Validation

- `git diff --check`
- `npm run build` in `docs/`
