### PR TITLE
fix(upgrade): stop re-sealing step registry on every boot

### DIFF
--- a/internal/storage/migration/upgrade/upgrade.go
+++ b/internal/storage/migration/upgrade/upgrade.go
@@ -33,6 +33,7 @@ import (
 	"github.com/goposta/posta/internal/models"
 	"github.com/jkaninda/logger"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // Settings keys persisted in the platform `settings` table.
@@ -79,6 +80,11 @@ func runLocked(ctx context.Context, db *gorm.DB, binaryVersion string, opts Opti
 	case fresh:
 		if err := markAllApplied(db, binaryVersion); err != nil {
 			return fmt.Errorf("upgrade: bootstrap fresh install: %w", err)
+		}
+		// Record the version even for dev builds, otherwise the next boot reads
+		// no app.version row, decides it is fresh again, and re-seals the registry.
+		if err := writeVersion(db, binaryVersion); err != nil {
+			return fmt.Errorf("upgrade: bootstrap persist version: %w", err)
 		}
 		logger.Info("upgrade: fresh install, sealed step registry", "version", binaryVersion)
 
@@ -165,5 +171,5 @@ func markAllApplied(db *gorm.DB, binaryVersion string) error {
 			AppliedAt:  now,
 		})
 	}
-	return db.Create(&rows).Error
+	return db.Clauses(clause.OnConflict{DoNothing: true}).Create(&rows).Error
 }


### PR DESCRIPTION
## Problem

On every startup the server aborts with:

```
ERROR: duplicate key value violates unique constraint "upgrade_steps_pkey" (SQLSTATE 23505)
INSERT INTO "upgrade_steps" ... VALUES ('2026-05-31-personal-workspaces','dev',...), ...
ERROR msg=failed to run upgrade steps error=upgrade: bootstrap fresh install: ...
```

## Root cause

`runLocked` only persists `app.version` when `!IsDev(binaryVersion)`. A dev build therefore never writes the row, so `readVersion` keeps returning `fresh = true` on every boot, `markAllApplied` re-inserts the whole registry, and the insert collides with the rows written by the first successful boot.

Secondary effect: because a dev build is always "fresh", newly added registry steps get auto-sealed instead of applied, so they can never be exercised locally.

## Fix

- Persist the version inside the fresh-install branch, regardless of `IsDev`. The next boot takes the `IsDev` branch (version pin still skipped) and `applyPending` runs any new steps normally.
- Make the seal idempotent with `ON CONFLICT DO NOTHING`, so databases already stuck in the broken state (steps present, no `app.version`) can boot again without manual SQL.

## Testing

`go build ./...` and `go vet ./internal/storage/migration/upgrade/` pass. No unit test added — the package has no database test harness (Postgres-only, no sqlite driver in the module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)