### PR TITLE
feat(dashboard): rework the workspace dashboard and admin metrics

### DIFF
--- a/internal/handlers/dashboard_handler.go
+++ b/internal/handlers/dashboard_handler.go
@@ -17,6 +17,13 @@ type DashboardHandler struct {
 	db             *gorm.DB
 	cache          *cache.Cache
 	whDeliveryRepo *repositories.WebhookDeliveryRepository
+	features       DashboardFeatures
+}
+
+type DashboardFeatures struct {
+	Messages bool `json:"messages"`
+	Inbound  bool `json:"inbound"`
+	Relay    bool `json:"relay"`
 }
 
 type DashboardStats struct {
@@ -40,6 +47,20 @@ type DashboardStats struct {
 	FailedInbound     int64         `json:"failed_inbound"`
 	DailyVolume       []DailyVolume `json:"daily_volume"`
 
+	UnverifiedDomains int64   `json:"unverified_domains"`
+	ExpiringAPIKeys   int64   `json:"expiring_api_keys"`
+	BounceRate        float64 `json:"bounce_rate"`
+
+	TotalForms      int64 `json:"total_forms"`
+	TotalMessages   int64 `json:"total_messages"`
+	UnreadMessages  int64 `json:"unread_messages"`
+	SpamMessages    int64 `json:"spam_messages"`
+	TotalTemplates  int64 `json:"total_templates"`
+	TotalCampaigns  int64 `json:"total_campaigns"`
+	TotalSubscriber int64 `json:"total_subscribers"`
+
+	Features DashboardFeatures `json:"features"`
+
 	// Webhook delivery stats
 	WebhookDeliveries *repositories.WebhookDeliveryStats `json:"webhook_deliveries"`
 }
@@ -53,6 +74,8 @@ type DailyVolume struct {
 func NewDashboardHandler(db *gorm.DB, c *cache.Cache, whDeliveryRepo *repositories.WebhookDeliveryRepository) *DashboardHandler {
 	return &DashboardHandler{db: db, cache: c, whDeliveryRepo: whDeliveryRepo}
 }
+
+func (h *DashboardHandler) SetFeatures(f DashboardFeatures) { h.features = f }
 
 func (h *DashboardHandler) Stats(c *okapi.Context) error {
 	scope := getScope(c)
@@ -83,11 +106,16 @@ func (h *DashboardHandler) Stats(c *okapi.Context) error {
 
 	// Infrastructure counts
 	applyScope(&models.Domain{}).Count(&stats.TotalDomains)
+	applyScope(&models.Domain{}).Where("ownership_verified = false").Count(&stats.UnverifiedDomains)
 	applyScope(&models.SMTPServer{}).Count(&stats.TotalSmtpServers)
 
 	// API keys
+	now := time.Now()
 	applyScope(&models.APIKey{}).Count(&stats.TotalAPIKeys)
-	applyScope(&models.APIKey{}).Where("revoked = false AND (expires_at IS NULL OR expires_at > ?)", time.Now()).Count(&stats.ActiveAPIKeys)
+	applyScope(&models.APIKey{}).Where("revoked = false AND (expires_at IS NULL OR expires_at > ?)", now).Count(&stats.ActiveAPIKeys)
+	applyScope(&models.APIKey{}).
+		Where("revoked = false AND expires_at IS NOT NULL AND expires_at > ? AND expires_at <= ?", now, now.AddDate(0, 0, 7)).
+		Count(&stats.ExpiringAPIKeys)
 
 	// Contacts & deliverability
 	applyScope(&models.Contact{}).Count(&stats.TotalContacts)
@@ -100,10 +128,34 @@ func (h *DashboardHandler) Stats(c *okapi.Context) error {
 	applyScope(&models.InboundEmail{}).Where("status = ?", models.InboundStatusForwarded).Count(&stats.ForwardedInbound)
 	applyScope(&models.InboundEmail{}).Where("status = ?", models.InboundStatusFailed).Count(&stats.FailedInbound)
 
-	// Failure rate
+	// Content and audience counts
+	applyScope(&models.Template{}).Count(&stats.TotalTemplates)
+	applyScope(&models.Campaign{}).Count(&stats.TotalCampaigns)
+	applyScope(&models.Subscriber{}).Count(&stats.TotalSubscriber)
+
+	// Web form messages
+	if h.features.Messages {
+		applyScope(&models.Form{}).Count(&stats.TotalForms)
+		applyScope(&models.Message{}).
+			Where("status <> ? AND deleted_at IS NULL", models.MessageStatusRejected).
+			Count(&stats.TotalMessages)
+		applyScope(&models.Message{}).
+			Where("read_at IS NULL AND deleted_at IS NULL AND status IN ?",
+				[]models.MessageStatus{models.MessageStatusReceived, models.MessageStatusFlagged}).
+			Count(&stats.UnreadMessages)
+		applyScope(&models.Message{}).
+			Where("deleted_at IS NULL AND status IN ?",
+				[]models.MessageStatus{models.MessageStatusQuarantined, models.MessageStatusRejected}).
+			Count(&stats.SpamMessages)
+	}
+
+	// Failure and bounce rates
 	if stats.TotalEmails > 0 {
 		stats.FailureRate = float64(stats.FailedEmails) / float64(stats.TotalEmails) * 100
+		stats.BounceRate = float64(stats.TotalBounces) / float64(stats.TotalEmails) * 100
 	}
+
+	stats.Features = h.features
 
 	// Webhook delivery stats
 	if whStats, err := h.whDeliveryRepo.StatsByScope(scope); err == nil {

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -303,6 +303,12 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	passwordResetSvc := passwordreset.NewService(userRepo, repositories.NewPasswordResetRepository(db), notif, cfg.AppWebURL)
 	r.h.user.SetPasswordReset(passwordResetSvc)
 
+	r.h.dashboard.SetFeatures(handlers.DashboardFeatures{
+		Messages: cfg.MessagesEnabled,
+		Inbound:  cfg.InboundEnabled,
+		Relay:    cfg.SMTPRelayEnabled,
+	})
+
 	// Email content privacy
 	r.h.email.SetSettings(settingsProvider)
 	r.h.admin.SetEmailSettings(settingsProvider)

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -483,11 +483,28 @@ export interface DashboardStats {
   total_suppressions: number
   total_webhooks: number
   total_contact_lists: number
-  total_inbound?: number
-  forwarded_inbound?: number
-  failed_inbound?: number
+  total_inbound: number
+  forwarded_inbound: number
+  failed_inbound: number
   daily_volume: DailyVolume[]
   webhook_deliveries: WebhookDeliveryStats | null
+  unverified_domains: number
+  expiring_api_keys: number
+  bounce_rate: number
+  total_forms: number
+  total_messages: number
+  unread_messages: number
+  spam_messages: number
+  total_templates: number
+  total_campaigns: number
+  total_subscribers: number
+  features: DashboardFeatures
+}
+
+export interface DashboardFeatures {
+  messages: boolean
+  inbound: boolean
+  relay: boolean
 }
 
 export interface DailyVolume {
@@ -526,6 +543,8 @@ export interface AdminMetrics {
   failed_logins_last_24h: number
   two_factor_adoption_rate: number
   two_factor_users: number
+  users_unmigrated: number
+  users_migration_failed: number
 }
 
 export interface WorkerStatus {

--- a/web/src/components/Sparkline.vue
+++ b/web/src/components/Sparkline.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    values: number[];
+    width?: number;
+    height?: number;
+    stroke?: string;
+  }>(),
+  {
+    width: 120,
+    height: 32,
+    stroke: "var(--primary-500)",
+  }
+);
+
+const pad = 2;
+
+const line = computed(() => {
+  const v = props.values;
+  if (v.length < 2) return "";
+  const max = Math.max(...v);
+  const min = Math.min(...v);
+  const range = max - min || 1;
+  const step = (props.width - pad * 2) / (v.length - 1);
+  return v
+    .map((val, i) => {
+      const x = pad + i * step;
+      const y = pad + (props.height - pad * 2) * (1 - (val - min) / range);
+      return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+});
+
+const area = computed(() => {
+  if (!line.value) return "";
+  return `${line.value} L${props.width - pad},${props.height - pad} L${pad},${props.height - pad} Z`;
+});
+</script>
+
+<template>
+  <svg
+    :width="width"
+    :height="height"
+    :viewBox="`0 0 ${width} ${height}`"
+    class="sparkline"
+    preserveAspectRatio="none"
+    aria-hidden="true"
+  >
+    <path v-if="area" :d="area" class="spark-area" :style="{ fill: stroke }" />
+    <path v-if="line" :d="line" class="spark-line" :style="{ stroke }" fill="none" />
+  </svg>
+</template>
+
+<style scoped>
+.sparkline {
+  display: block;
+  overflow: visible;
+}
+.spark-line {
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+.spark-area {
+  opacity: 0.12;
+}
+</style>

--- a/web/src/views/admin/AdminHealth.vue
+++ b/web/src/views/admin/AdminHealth.vue
@@ -1,0 +1,387 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import Sparkline from "../../components/Sparkline.vue";
+import type { AdminMetrics, WorkerStatus } from "../../api/types";
+
+const props = defineProps<{
+  metrics: AdminMetrics;
+  workerStatus: WorkerStatus | null;
+  activeWorkers: number;
+  trends: { memory: number[]; goroutines: number[]; workers: number[] };
+}>();
+
+type Level = "ok" | "warn" | "crit";
+
+const rank: Record<Level, number> = { ok: 0, warn: 1, crit: 2 };
+
+interface Meter {
+  key: string;
+  label: string;
+  value: string;
+  detail: string;
+  pct: number;
+  level: Level;
+  hint?: string;
+}
+
+function levelFor(pct: number, warn: number, crit: number): Level {
+  if (pct <= crit) return "crit";
+  if (pct <= warn) return "warn";
+  return "ok";
+}
+
+const deliveryRate = computed(() => {
+  const m = props.metrics;
+  const attempted = m.sent_emails + m.failed_emails;
+  return attempted === 0 ? 100 : (m.sent_emails / attempted) * 100;
+});
+
+const meters = computed<Meter[]>(() => {
+  const m = props.metrics;
+  const out: Meter[] = [];
+
+  const attempted = m.sent_emails + m.failed_emails;
+  if (attempted > 0) {
+    const pct = deliveryRate.value;
+    out.push({
+      key: "delivery",
+      label: "Delivery rate",
+      value: `${pct.toFixed(1)}%`,
+      detail: `${m.sent_emails.toLocaleString()} delivered of ${attempted.toLocaleString()} attempted`,
+      pct,
+      level: levelFor(pct, 95, 90),
+      hint: pct <= 95 ? "Check SMTP server health and the most recent failures." : undefined,
+    });
+  }
+
+  if (m.total_users > 0) {
+    const pct = m.two_factor_adoption_rate;
+    out.push({
+      key: "twofa",
+      label: "Two-factor adoption",
+      value: `${pct.toFixed(0)}%`,
+      detail: `${m.two_factor_users} of ${m.total_users} users enrolled`,
+      pct,
+      level: levelFor(pct, 50, 20),
+      hint: pct <= 50 ? "Consider requiring 2FA in platform settings." : undefined,
+    });
+  }
+
+  if (m.total_api_keys > 0) {
+    const pct = (m.active_api_keys / m.total_api_keys) * 100;
+    out.push({
+      key: "keys",
+      label: "API keys active",
+      value: `${m.active_api_keys}/${m.total_api_keys}`,
+      detail: `${m.total_api_keys - m.active_api_keys} revoked or expired`,
+      pct,
+      level: "ok",
+    });
+  }
+
+  return out;
+});
+
+const health = computed(() => {
+  const m = props.metrics;
+  const reasons: string[] = [];
+  let worst = 0;
+  const raise = (l: Level) => {
+    worst = Math.max(worst, rank[l]);
+  };
+
+  if (props.activeWorkers === 0) {
+    raise("crit");
+    reasons.push(
+      m.queued_emails > 0
+        ? `No workers connected — ${m.queued_emails.toLocaleString()} email(s) are stuck in the queue`
+        : "No workers connected — queued email will not be delivered"
+    );
+  }
+
+  if (m.users_migration_failed > 0) {
+    raise("crit");
+    reasons.push(`Workspace migration failed for ${m.users_migration_failed} user(s)`);
+  }
+
+  if (m.users_unmigrated > 0) {
+    raise("warn");
+    reasons.push(`${m.users_unmigrated} user(s) have not been migrated to a workspace`);
+  }
+
+  for (const meter of meters.value) {
+    if (meter.level === "ok") continue;
+    raise(meter.level);
+    reasons.push(`${meter.label} at ${meter.value}`);
+  }
+
+  if (props.workerStatus?.version_mismatch) {
+    raise("warn");
+    reasons.push(
+      `A worker is running a different version than the server (${props.workerStatus.server_version || "unknown"})`
+    );
+  }
+
+  if (m.failed_logins_last_24h >= 10) {
+    raise("warn");
+    reasons.push(`${m.failed_logins_last_24h} failed sign-ins in the last 24 hours`);
+  }
+
+  if (worst === 2) return { level: "crit" as Level, label: "Needs attention", reasons };
+  if (worst === 1) return { level: "warn" as Level, label: "Degraded", reasons };
+  return { level: "ok" as Level, label: "Operational", reasons };
+});
+
+function formatBytes(bytes: number): string {
+  if (!bytes || bytes < 0) return "—";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let i = 0;
+  let n = bytes;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  return `${n.toFixed(n >= 100 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function formatUptime(seconds: number): string {
+  if (!seconds || seconds < 0) return "—";
+  const s = Math.floor(seconds);
+  const d = Math.floor(s / 86400);
+  const h = Math.floor((s % 86400) / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+</script>
+
+<template>
+  <div class="card health-card" :class="`health-${health.level}`">
+    <div class="health-head">
+      <span class="health-mark" aria-hidden="true">
+        <svg v-if="health.level === 'ok'" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="10" /><path d="m8 12 3 3 5-6" />
+        </svg>
+        <svg v-else-if="health.level === 'warn'" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+          <line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+        <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2" />
+          <line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
+        </svg>
+      </span>
+      <div class="health-text">
+        <span class="health-label">{{ health.label }}</span>
+        <span v-if="!health.reasons.length" class="health-sub">
+          Workers connected, delivery healthy, no migration backlog.
+        </span>
+        <ul v-else class="health-reasons">
+          <li v-for="reason in health.reasons" :key="reason">{{ reason }}</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="runtime-row">
+      <div class="rt">
+        <span class="rt-label">Uptime</span>
+        <span class="rt-value">{{ formatUptime(metrics.server_uptime_seconds) }}</span>
+      </div>
+      <div class="rt">
+        <span class="rt-label">Workers</span>
+        <span class="rt-value" :class="activeWorkers === 0 ? 'tone-danger' : ''">{{ activeWorkers }}</span>
+        <Sparkline
+          :values="trends.workers"
+          :width="90"
+          :height="24"
+          :stroke="activeWorkers === 0 ? 'var(--danger-500)' : 'var(--success-500)'"
+        />
+      </div>
+      <div class="rt">
+        <span class="rt-label">Memory</span>
+        <span class="rt-value">{{ formatBytes(metrics.current_memory_usage) }}</span>
+        <Sparkline :values="trends.memory" :width="90" :height="24" />
+      </div>
+      <div class="rt">
+        <span class="rt-label">Goroutines</span>
+        <span class="rt-value">{{ metrics.current_goroutines.toLocaleString() }}</span>
+        <Sparkline :values="trends.goroutines" :width="90" :height="24" />
+      </div>
+      <div class="rt">
+        <span class="rt-label">Queue</span>
+        <span class="rt-value">{{ (metrics.queued_emails + metrics.processing_emails).toLocaleString() }}</span>
+        <span class="rt-sub">{{ metrics.queued_emails.toLocaleString() }} queued</span>
+      </div>
+    </div>
+
+    <div v-if="meters.length" class="meters">
+      <div v-for="meter in meters" :key="meter.key" class="meter" :class="`meter-${meter.level}`">
+        <div class="meter-head">
+          <span class="meter-label">{{ meter.label }}</span>
+          <span class="meter-value">{{ meter.value }}</span>
+        </div>
+        <div class="meter-track">
+          <div class="meter-fill" :style="{ width: `${Math.min(100, Math.max(0, meter.pct))}%` }"></div>
+        </div>
+        <div class="meter-detail">{{ meter.detail }}</div>
+        <div v-if="meter.hint" class="meter-hint">{{ meter.hint }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.health-card {
+  padding: 20px 24px;
+  border-left: 3px solid var(--border-primary);
+}
+
+.health-ok { border-left-color: var(--success-500); }
+.health-warn { border-left-color: var(--warning-500); }
+.health-crit { border-left-color: var(--danger-500); }
+
+.health-head {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.health-mark {
+  flex: none;
+  width: 24px;
+  height: 24px;
+}
+
+.health-mark svg {
+  width: 24px;
+  height: 24px;
+}
+
+.health-ok .health-mark { color: var(--success-600); }
+.health-warn .health-mark { color: var(--warning-600); }
+.health-crit .health-mark { color: var(--danger-600); }
+
+.health-text {
+  min-width: 0;
+}
+
+.health-label {
+  display: block;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.health-sub {
+  font-size: 13px;
+  color: var(--text-tertiary);
+}
+
+.health-reasons {
+  margin: 6px 0 0;
+  padding-left: 18px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.health-reasons li {
+  margin-bottom: 3px;
+}
+
+.runtime-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 16px;
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border-secondary);
+}
+
+.rt {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.rt-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  color: var(--text-tertiary);
+}
+
+.rt-value {
+  font-size: 19px;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.rt-sub {
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.tone-danger { color: var(--danger-600); }
+
+.meters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border-secondary);
+}
+
+.meter-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.meter-label {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.meter-value {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.meter-track {
+  height: 5px;
+  border-radius: 999px;
+  background: var(--bg-tertiary);
+  overflow: hidden;
+}
+
+.meter-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--success-500);
+  transition: width 0.3s ease;
+}
+
+.meter-warn .meter-fill { background: var(--warning-500); }
+.meter-crit .meter-fill { background: var(--danger-500); }
+
+.meter-detail {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.meter-hint {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+</style>

--- a/web/src/views/admin/AdminQuickLinks.vue
+++ b/web/src/views/admin/AdminQuickLinks.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { useRouter } from "vue-router";
+import type { AdminMetrics } from "../../api/types";
+
+const props = defineProps<{ metrics: AdminMetrics }>();
+const router = useRouter();
+
+const links = [
+  { to: "/admin/users", label: "Users", count: () => props.metrics.total_users },
+  { to: "/admin/workspaces", label: "Workspaces", count: () => props.metrics.total_workspaces },
+  { to: "/admin/servers", label: "Shared SMTP", count: () => props.metrics.shared_smtp_servers },
+  { to: "/admin/plans", label: "Plans", count: () => undefined },
+  { to: "/admin/jobs", label: "Jobs", count: () => undefined },
+  { to: "/admin/events", label: "Events", count: () => undefined },
+  { to: "/admin/settings", label: "Settings", count: () => undefined },
+];
+</script>
+
+<template>
+  <div class="ql-row">
+    <button v-for="l in links" :key="l.to" class="ql" @click="router.push(l.to)">
+      <span class="ql-label">{{ l.label }}</span>
+      <span v-if="l.count() !== undefined" class="ql-count">{{ l.count()!.toLocaleString() }}</span>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.ql-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.ql {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 13px;
+  border-radius: 8px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, transform 0.15s;
+}
+
+.ql:hover {
+  border-color: var(--primary-500);
+  background: var(--bg-hover);
+  transform: translateY(-1px);
+}
+
+.ql-count {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  background: var(--bg-tertiary);
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 719px) {
+  .ql-row {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .ql-row::-webkit-scrollbar { display: none; }
+  .ql { flex: 0 0 auto; }
+}
+</style>

--- a/web/src/views/admin/Metrics.vue
+++ b/web/src/views/admin/Metrics.vue
@@ -2,7 +2,25 @@
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { adminApi } from '../../api/admin'
 import { analyticsApi } from '../../api/analytics'
+import { useNotificationStore } from '../../stores/notification'
+import { apiMessage } from '../../composables/apiError'
+import AdminHealth from './AdminHealth.vue'
+import AdminQuickLinks from './AdminQuickLinks.vue'
 import type { AdminMetrics, WorkerStatus, SystemStatus, AnalyticsResponse, DashboardAnalyticsResponse } from '../../api/types'
+
+const notify = useNotificationStore()
+
+const TREND_POINTS = 20
+const trends = ref<{ memory: number[]; goroutines: number[]; workers: number[] }>({
+  memory: [],
+  goroutines: [],
+  workers: [],
+})
+
+function pushTrend(series: number[], value: number) {
+  series.push(value)
+  if (series.length > TREND_POINTS) series.shift()
+}
 
 const loading = ref(true)
 const metrics = ref<AdminMetrics | null>(null)
@@ -21,8 +39,11 @@ onMounted(async () => {
     metrics.value = metricsRes.data.data
     analytics.value = analyticsRes.data.data
     dashAnalytics.value = dashRes.data.data
-  } catch (e) {
-    console.error('Failed to load metrics', e)
+    pushTrend(trends.value.memory, metrics.value.current_memory_usage)
+    pushTrend(trends.value.goroutines, metrics.value.current_goroutines)
+    pushTrend(trends.value.workers, metrics.value.active_workers)
+  } catch (e: any) {
+    notify.error(apiMessage(e, 'Failed to load platform metrics'))
   } finally {
     loading.value = false
   }
@@ -46,6 +67,7 @@ function startWorkerStream() {
       if (metrics.value) {
         metrics.value.active_workers = status.active_workers
       }
+      pushTrend(trends.value.workers, status.active_workers)
     } catch {
       // ignore parse errors
     }
@@ -58,6 +80,8 @@ function startWorkerStream() {
         metrics.value.server_uptime_seconds = status.server_uptime_seconds
         metrics.value.current_goroutines = status.current_goroutines
         metrics.value.current_memory_usage = status.current_memory_usage
+        pushTrend(trends.value.memory, status.current_memory_usage)
+        pushTrend(trends.value.goroutines, status.current_goroutines)
       }
     } catch {
       // ignore parse errors
@@ -198,7 +222,14 @@ const avgDeliveryRate = computed(() => {
 <template>
   <div>
     <div class="page-header">
-      <h1>Platform Metrics</h1>
+      <div>
+        <h1>Platform Metrics</h1>
+        <p class="page-subtitle">Platform health and activity at a glance</p>
+      </div>
+      <div class="live-indicator" :class="{ 'is-live': activeWorkers > 0 }">
+        <span class="live-dot"></span>
+        <span>Live</span>
+      </div>
     </div>
 
     <div v-if="loading" class="loading-page">
@@ -206,6 +237,16 @@ const avgDeliveryRate = computed(() => {
     </div>
 
     <template v-else-if="metrics">
+      <AdminQuickLinks :metrics="metrics" />
+
+      <AdminHealth
+        :metrics="metrics"
+        :worker-status="workerStatus"
+        :active-workers="activeWorkers"
+        :trends="trends"
+        style="margin-bottom: 28px"
+      />
+
       <!-- Overview -->
       <div class="metrics-section-label">Overview</div>
       <div class="stats-grid">
@@ -752,6 +793,44 @@ const avgDeliveryRate = computed(() => {
 </template>
 
 <style scoped>
+.page-subtitle {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.live-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex: none;
+}
+
+.live-indicator.is-live { color: var(--success-600); }
+.live-indicator.is-live .live-dot {
+  background: var(--success-500);
+  animation: live-blink 1.8s ease-in-out infinite;
+}
+
+@keyframes live-blink {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.45); }
+  50% { opacity: 0.55; box-shadow: 0 0 0 4px rgba(34, 197, 94, 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .live-indicator.is-live .live-dot { animation: none; }
+}
+
 .metrics-section-label {
   font-size: 12px;
   font-weight: 700;

--- a/web/src/views/dashboard/Dashboard.vue
+++ b/web/src/views/dashboard/Dashboard.vue
@@ -1,534 +1,272 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
-import { dashboardApi } from '../../api/dashboard'
-import { emailsApi } from '../../api/emails'
-import type { DashboardStats, Email } from '../../api/types'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import { storeToRefs } from "pinia";
+import { dashboardApi } from "../../api/dashboard";
+import { emailsApi } from "../../api/emails";
+import { useAuthStore } from "../../stores/auth";
+import { useWorkspaceStore } from "../../stores/workspace";
+import { useNotificationStore } from "../../stores/notification";
+import { apiMessage } from "../../composables/apiError";
+import type { DashboardStats, Email } from "../../api/types";
+import GettingStarted from "./GettingStarted.vue";
+import HealthAlerts from "./HealthAlerts.vue";
+import OverviewStats from "./OverviewStats.vue";
+import QuickActions from "./QuickActions.vue";
+import RecentEmails from "./RecentEmails.vue";
+import ResourceCards from "./ResourceCards.vue";
+import VolumeChart from "./VolumeChart.vue";
 
-const router = useRouter()
-const loading = ref(true)
-const stats = ref<DashboardStats | null>(null)
-const recentEmails = ref<Email[]>([])
+const CHECKLIST_KEY = "posta_dashboard_checklist_dismissed";
+const REFRESH_MS = 60_000;
 
-onMounted(async () => {
+const router = useRouter();
+const auth = useAuthStore();
+const ws = useWorkspaceStore();
+const notify = useNotificationStore();
+const { currentWorkspaceId } = storeToRefs(ws);
+
+const loading = ref(true);
+const refreshing = ref(false);
+const stats = ref<DashboardStats | null>(null);
+const recentEmails = ref<Email[]>([]);
+const updatedAt = ref<Date | null>(null);
+const now = ref(Date.now());
+const checklistDismissed = ref(localStorage.getItem(CHECKLIST_KEY) === "true");
+
+let refreshTimer: number | undefined;
+let clockTimer: number | undefined;
+
+const greeting = computed(() => {
+  const h = new Date().getHours();
+  const part = h < 12 ? "Good morning" : h < 18 ? "Good afternoon" : "Good evening";
+  const name = auth.user?.name?.trim().split(" ")[0];
+  return name ? `${part}, ${name}` : part;
+});
+
+const health = computed(() => {
+  const s = stats.value;
+  if (!s) return { tone: "neutral", text: "Loading…" };
+  if (s.total_emails === 0) return { tone: "neutral", text: "Nothing sent yet" };
+  if (s.failure_rate >= 10 || s.bounce_rate >= 5) {
+    return { tone: "danger", text: "Delivery needs attention" };
+  }
+  if (s.unverified_domains > 0 || s.expiring_api_keys > 0) {
+    return { tone: "warning", text: "Configuration needs attention" };
+  }
+  return { tone: "success", text: "Delivery healthy" };
+});
+
+const showChecklist = computed(() => !checklistDismissed.value && !!stats.value);
+
+const updatedLabel = computed(() => {
+  if (!updatedAt.value) return "";
+  const secs = Math.max(0, Math.floor((now.value - updatedAt.value.getTime()) / 1000));
+  if (secs < 10) return "just now";
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  return `${Math.floor(mins / 60)}h ago`;
+});
+
+async function load(showSpinner: boolean) {
+  if (showSpinner) loading.value = true;
+  else refreshing.value = true;
   try {
     const [statsRes, emailsRes] = await Promise.all([
       dashboardApi.getStats(),
-      emailsApi.list(0, 10),
-    ])
-    stats.value = statsRes.data.data
-    recentEmails.value = emailsRes.data.data
-  } catch (e) {
-    console.error('Failed to load dashboard data', e)
+      emailsApi.list(0, 8),
+    ]);
+    stats.value = statsRes.data.data;
+    recentEmails.value = emailsRes.data.data;
+    updatedAt.value = new Date();
+  } catch (e: any) {
+    notify.error(apiMessage(e, "Failed to load the dashboard"));
   } finally {
-    loading.value = false
-  }
-})
-
-const chartMax = computed(() => {
-  if (!stats.value?.daily_volume) return 1
-  const max = Math.max(...stats.value.daily_volume.map(d => d.sent + d.failed))
-  return max || 1
-})
-
-function chartBarHeight(value: number): string {
-  const pct = (value / chartMax.value) * 100
-  return `${Math.max(pct, value > 0 ? 2 : 0)}%`
-}
-
-function formatChartDate(dateStr: string): string {
-  const d = new Date(dateStr + 'T00:00:00')
-  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-}
-
-function formatChartWeekday(dateStr: string): string {
-  const d = new Date(dateStr + 'T00:00:00')
-  return d.toLocaleDateString(undefined, { weekday: 'short' })
-}
-
-function statusBadgeClass(status: string) {
-  switch (status) {
-    case 'sent': return 'badge badge-success'
-    case 'failed': return 'badge badge-danger'
-    case 'pending': return 'badge badge-warning'
-    case 'queued': return 'badge badge-info'
-    case 'processing': return 'badge badge-warning'
-    case 'suppressed': return 'badge badge-secondary'
-    case 'scheduled': return 'badge badge-info'
-    default: return 'badge'
+    loading.value = false;
+    refreshing.value = false;
   }
 }
 
-function formatDate(date: string | null) {
-  if (!date) return '-'
-  return new Date(date).toLocaleString()
+function dismissChecklist() {
+  checklistDismissed.value = true;
+  localStorage.setItem(CHECKLIST_KEY, "true");
 }
 
-function formatNumber(n: number): string {
-  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M'
-  if (n >= 10_000) return (n / 1_000).toFixed(1) + 'K'
-  return n.toLocaleString()
-}
+onMounted(() => {
+  load(true);
+  refreshTimer = window.setInterval(() => {
+    if (document.visibilityState === "visible") load(false);
+  }, REFRESH_MS);
+  clockTimer = window.setInterval(() => {
+    now.value = Date.now();
+  }, 10_000);
+});
 
-const deliveryRate = computed(() => {
-  if (!stats.value || stats.value.total_emails === 0) return 0
-  return ((stats.value.sent_emails / stats.value.total_emails) * 100)
-})
+onBeforeUnmount(() => {
+  window.clearInterval(refreshTimer);
+  window.clearInterval(clockTimer);
+});
 
-const totalVolume14d = computed(() => {
-  if (!stats.value?.daily_volume) return 0
-  return stats.value.daily_volume.reduce((sum, d) => sum + d.sent + d.failed, 0)
-})
+watch(currentWorkspaceId, () => load(true));
 </script>
 
 <template>
   <div>
     <div class="page-header">
-      <h1>Dashboard</h1>
+      <div>
+        <h1>{{ greeting }}</h1>
+        <p class="subtitle">
+          Overview of <strong>{{ ws.contextLabel }}</strong>
+          <span v-if="stats" class="health-pill" :class="`health-${health.tone}`">{{ health.text }}</span>
+        </p>
+      </div>
+      <div class="header-actions">
+        <span v-if="updatedAt" class="updated" :title="updatedAt.toLocaleString()">
+          Updated {{ updatedLabel }}
+        </span>
+        <button class="btn btn-secondary" :disabled="refreshing || loading" @click="load(false)">
+          {{ refreshing ? "Refreshing…" : "Refresh" }}
+        </button>
+        <button class="btn btn-primary" @click="router.push('/emails')">View emails</button>
+      </div>
     </div>
 
-    <div v-if="loading" class="loading-page">
-      <div class="spinner"></div>
+    <div v-if="loading" class="stats-grid">
+      <div v-for="i in 4" :key="i" class="stat-card">
+        <span class="skeleton skeleton-line" style="width: 45%"></span>
+        <span class="skeleton skeleton-line skeleton-value"></span>
+        <span class="skeleton skeleton-line" style="width: 70%"></span>
+      </div>
     </div>
 
     <template v-else-if="stats">
-      <!-- Primary stats row -->
-      <div class="stats-grid">
-        <div class="stat-card">
-          <div class="stat-header">
-            <div class="stat-label">Total Emails</div>
-            <div class="stat-icon stat-icon-primary">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
-            </div>
-          </div>
-          <div class="stat-value">{{ formatNumber(stats.total_emails) }}</div>
-        </div>
-        <div class="stat-card">
-          <div class="stat-header">
-            <div class="stat-label">Sent</div>
-            <div class="stat-icon stat-icon-success">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
-            </div>
-          </div>
-          <div class="stat-value">{{ formatNumber(stats.sent_emails) }}</div>
-        </div>
-        <div class="stat-card">
-          <div class="stat-header">
-            <div class="stat-label">Failed</div>
-            <div class="stat-icon stat-icon-danger">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
-            </div>
-          </div>
-          <div class="stat-value">{{ formatNumber(stats.failed_emails) }}</div>
-          <div class="stat-sub">{{ stats.failure_rate.toFixed(1) }}% failure rate</div>
-        </div>
-        <div class="stat-card">
-          <div class="stat-header">
-            <div class="stat-label">Delivery Rate</div>
-            <div class="stat-icon stat-icon-success">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
-            </div>
-          </div>
-          <div class="stat-value">{{ deliveryRate.toFixed(1) }}%</div>
-          <div class="stat-sub">{{ formatNumber(stats.sent_emails) }} of {{ formatNumber(stats.total_emails) }} delivered</div>
-        </div>
-        <div v-if="stats.queued_emails > 0 || stats.processing_emails > 0" class="stat-card">
-          <div class="stat-header">
-            <div class="stat-label">In Queue</div>
-            <div class="stat-icon stat-icon-info">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-            </div>
-          </div>
-          <div class="stat-value">{{ formatNumber(stats.queued_emails + stats.processing_emails) }}</div>
-        </div>
-        <div v-if="(stats.total_inbound ?? 0) > 0" class="stat-card" style="cursor: pointer" @click="$router.push('/inbound-emails')">
-          <div class="stat-header">
-            <div class="stat-label">Inbound</div>
-            <div class="stat-icon stat-icon-info">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/><path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>
-            </div>
-          </div>
-          <div class="stat-value">{{ formatNumber(stats.total_inbound ?? 0) }}</div>
-          <div class="stat-sub">{{ formatNumber(stats.forwarded_inbound ?? 0) }} forwarded · {{ formatNumber(stats.failed_inbound ?? 0) }} failed</div>
-        </div>
+      <HealthAlerts :stats="stats" />
+
+      <GettingStarted v-if="showChecklist" :stats="stats" @dismiss="dismissChecklist" />
+
+      <QuickActions :features="stats.features" />
+
+      <OverviewStats :stats="stats" />
+
+      <div class="dash-section">
+        <VolumeChart :volume="stats.daily_volume" />
       </div>
 
-      <!-- Daily volume chart -->
-      <div class="card" style="margin-top: 20px">
-        <div class="card-header">
-          <h2>Send Volume <span style="font-weight: 400; font-size: 13px; color: var(--text-muted)">Last 14 days &middot; {{ formatNumber(totalVolume14d) }} emails</span></h2>
+      <div class="dash-columns">
+        <div class="dash-main">
+          <RecentEmails :emails="recentEmails" />
         </div>
-        <div class="volume-chart">
-          <div class="volume-chart-bars">
-            <div
-              v-for="day in stats.daily_volume"
-              :key="day.date"
-              class="volume-bar-group"
-              :title="`${formatChartDate(day.date)}: ${day.sent} sent, ${day.failed} failed`"
-            >
-              <div class="volume-bar-stack">
-                <div class="volume-bar volume-bar-failed" :style="{ height: chartBarHeight(day.failed) }"></div>
-                <div class="volume-bar volume-bar-sent" :style="{ height: chartBarHeight(day.sent) }"></div>
-              </div>
-              <div class="volume-bar-label">{{ formatChartWeekday(day.date) }}</div>
-            </div>
-          </div>
-          <div class="volume-chart-legend">
-            <span class="volume-legend-item"><span class="volume-legend-dot volume-legend-sent"></span> Sent</span>
-            <span class="volume-legend-item"><span class="volume-legend-dot volume-legend-failed"></span> Failed</span>
-          </div>
-        </div>
-      </div>
-
-      <!-- Webhook Deliveries -->
-      <div v-if="stats.webhook_deliveries && stats.webhook_deliveries.total_deliveries > 0" class="card" style="margin-top: 20px">
-        <div class="card-header" style="display: flex; justify-content: space-between; align-items: center">
-          <h2>Webhook Deliveries</h2>
-          <button class="btn btn-secondary btn-sm" @click="router.push('/webhooks')">Manage Webhooks</button>
-        </div>
-        <div class="card-body">
-          <div class="wh-stats-row">
-            <div class="wh-stat">
-              <div class="wh-stat-value">{{ formatNumber(stats.webhook_deliveries.total_deliveries) }}</div>
-              <div class="wh-stat-label">Total</div>
-            </div>
-            <div class="wh-stat">
-              <div class="wh-stat-value wh-stat-success">{{ formatNumber(stats.webhook_deliveries.success_deliveries) }}</div>
-              <div class="wh-stat-label">Successful</div>
-            </div>
-            <div class="wh-stat">
-              <div class="wh-stat-value wh-stat-failed">{{ formatNumber(stats.webhook_deliveries.failed_deliveries) }}</div>
-              <div class="wh-stat-label">Failed</div>
-            </div>
-            <div class="wh-stat">
-              <div class="wh-stat-value" :class="stats.webhook_deliveries.success_rate >= 95 ? 'wh-stat-success' : stats.webhook_deliveries.success_rate >= 80 ? 'wh-stat-warning' : 'wh-stat-failed'">
-                {{ stats.webhook_deliveries.success_rate.toFixed(1) }}%
-              </div>
-              <div class="wh-stat-label">Success Rate</div>
-            </div>
-          </div>
-          <div class="wh-delivery-bar" v-if="stats.webhook_deliveries.total_deliveries > 0">
-            <div class="wh-delivery-segment wh-delivery-success" :style="{ width: stats.webhook_deliveries.success_rate + '%' }"></div>
-            <div class="wh-delivery-segment wh-delivery-failed" :style="{ width: (100 - stats.webhook_deliveries.success_rate) + '%' }"></div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Two-column layout: Infrastructure + Deliverability -->
-      <div class="dashboard-grid" style="margin-top: 20px">
-        <!-- Infrastructure -->
-        <div class="card">
-          <div class="card-header">
-            <h2>Infrastructure</h2>
-          </div>
-          <div class="dashboard-metric-list">
-            <div class="dashboard-metric" @click="router.push('/api-keys')" style="cursor: pointer">
-              <div class="dashboard-metric-label">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
-                API Keys
-              </div>
-              <div class="dashboard-metric-value">
-                <span>{{ stats.active_api_keys }}</span>
-                <span class="dashboard-metric-secondary">/ {{ stats.total_api_keys }}</span>
-              </div>
-            </div>
-            <div class="dashboard-metric" @click="router.push('/domains')" style="cursor: pointer">
-              <div class="dashboard-metric-label">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-                Domains
-              </div>
-              <div class="dashboard-metric-value">{{ stats.total_domains }}</div>
-            </div>
-            <div class="dashboard-metric" @click="router.push('/smtp-servers')" style="cursor: pointer">
-              <div class="dashboard-metric-label">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="8" rx="2"/><rect x="2" y="14" width="20" height="8" rx="2"/><line x1="6" y1="6" x2="6.01" y2="6"/><line x1="6" y1="18" x2="6.01" y2="18"/></svg>
-                SMTP Servers
-              </div>
-              <div class="dashboard-metric-value">{{ stats.total_smtp_servers }}</div>
-            </div>
-            <div class="dashboard-metric" @click="router.push('/webhooks')" style="cursor: pointer">
-              <div class="dashboard-metric-label">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 16.98h-5.99c-1.1 0-1.95.68-2.95 1.76C8.07 19.82 6.22 20 5 20c-1.22 0-2.2-.38-3-1"/><path d="M18 16.98h-5.99c-1.66 0-2.61-1.22-3.15-2.59C8.23 12.64 8 10.66 8 9c0-3.87 3.13-7 7-7"/><circle cx="12" cy="12" r="2"/></svg>
-                Webhooks
-              </div>
-              <div class="dashboard-metric-value">{{ stats.total_webhooks }}</div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Deliverability -->
-        <div class="card">
-          <div class="card-header">
-            <h2>Deliverability</h2>
-          </div>
-          <div class="dashboard-metric-list">
-            <div class="dashboard-metric" @click="router.push('/contacts')" style="cursor: pointer">
-              <div class="dashboard-metric-label">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
-                Contacts
-              </div>
-              <div class="dashboard-metric-value">{{ formatNumber(stats.total_contacts) }}</div>
-            </div>
-            <div class="dashboard-metric">
-              <div class="dashboard-metric-label">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/></svg>
-                Suppressed
-              </div>
-              <div class="dashboard-metric-value">{{ formatNumber(stats.suppressed_emails) }}</div>
-            </div>
-            <div class="dashboard-metric" @click="router.push('/bounces')" style="cursor: pointer">
-              <div class="dashboard-metric-label">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 17 4 12 9 7"/><path d="M20 18v-2a4 4 0 0 0-4-4H4"/></svg>
-                Bounces
-              </div>
-              <div class="dashboard-metric-value">{{ formatNumber(stats.total_bounces) }}</div>
-            </div>
-            <div class="dashboard-metric">
-              <div class="dashboard-metric-label">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-                Suppressions
-              </div>
-              <div class="dashboard-metric-value">{{ formatNumber(stats.total_suppressions) }}</div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Recent Emails -->
-      <div class="card" style="margin-top: 20px">
-        <div class="card-header" style="display: flex; justify-content: space-between; align-items: center">
-          <h2>Recent Emails</h2>
-          <button class="btn btn-secondary btn-sm" @click="router.push('/emails')">View All</button>
-        </div>
-        <div v-if="recentEmails.length === 0" class="empty-state">
-          <h3>No emails yet</h3>
-          <p>Emails sent through the API will appear here.</p>
-        </div>
-        <div v-else class="table-wrapper">
-          <table>
-            <thead>
-              <tr>
-                <th>Subject</th>
-                <th>Recipients</th>
-                <th>Status</th>
-                <th>Date</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="email in recentEmails"
-                :key="email.uuid"
-                style="cursor: pointer"
-                @click="router.push(`/emails/${email.uuid}`)"
-              >
-                <td>{{ email.subject }}</td>
-                <td>{{ email.recipients.join(', ') }}</td>
-                <td><span :class="statusBadgeClass(email.status)">{{ email.status }}</span></td>
-                <td>{{ formatDate(email.created_at) }}</td>
-              </tr>
-            </tbody>
-          </table>
+        <div class="dash-side">
+          <ResourceCards :stats="stats" />
         </div>
       </div>
     </template>
+
+    <div v-else class="card">
+      <div class="empty-state">
+        <h3>Dashboard unavailable</h3>
+        <p>The workspace statistics could not be loaded.</p>
+        <button class="btn btn-primary" @click="load(true)">Try again</button>
+      </div>
+    </div>
   </div>
 </template>
 
 <style scoped>
-.dashboard-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
+.subtitle {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  margin-top: 4px;
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 10px;
+  min-width: 0;
 }
 
-@media (max-width: 768px) {
-  .dashboard-grid {
-    grid-template-columns: 1fr;
+.subtitle strong {
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+
+.health-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.health-success { background: var(--success-50); color: var(--success-600); }
+.health-warning { background: var(--warning-50); color: var(--warning-600); }
+.health-danger { background: var(--danger-50); color: var(--danger-600); }
+.health-neutral { background: var(--bg-tertiary); color: var(--text-tertiary); }
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.updated {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.dash-section {
+  margin-top: 20px;
+}
+
+.dash-columns {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 20px;
+  align-items: start;
+  margin-top: 20px;
+}
+
+.dash-main,
+.dash-side {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 0;
+}
+
+@media (min-width: 1180px) {
+  .dash-columns {
+    grid-template-columns: minmax(0, 1.7fr) minmax(300px, 1fr);
   }
 }
 
-.dashboard-metric-list {
-  padding: 4px 0;
+.skeleton {
+  display: block;
+  border-radius: 6px;
+  background: linear-gradient(90deg, var(--bg-tertiary) 25%, var(--bg-hover) 37%, var(--bg-tertiary) 63%);
+  background-size: 400% 100%;
+  animation: skeleton-shimmer 1.4s ease infinite;
 }
 
-.dashboard-metric {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--border-light);
-  transition: background 0.15s ease;
+.skeleton-line {
+  height: 12px;
+  margin-bottom: 10px;
 }
 
-.dashboard-metric:last-child {
-  border-bottom: none;
+.skeleton-value {
+  height: 28px;
+  width: 55%;
 }
 
-.dashboard-metric:hover {
-  background: var(--bg-secondary);
+@keyframes skeleton-shimmer {
+  0% { background-position: 100% 50%; }
+  100% { background-position: 0 50%; }
 }
 
-.dashboard-metric-label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  color: var(--text-secondary);
-}
-
-.dashboard-metric-label svg {
-  color: var(--text-muted);
-  flex-shrink: 0;
-}
-
-.dashboard-metric-value {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.dashboard-metric-secondary {
-  font-weight: 400;
-  color: var(--text-muted);
-  font-size: 13px;
-}
-
-/* Webhook delivery stats */
-.wh-stats-row {
-  display: flex;
-  gap: 24px;
-  margin-bottom: 16px;
-}
-
-.wh-stat {
-  flex: 1;
-  text-align: center;
-}
-
-.wh-stat-value {
-  font-size: 22px;
-  font-weight: 700;
-  color: var(--text-primary);
-}
-
-.wh-stat-label {
-  font-size: 12px;
-  color: var(--text-muted);
-  margin-top: 2px;
-}
-
-.wh-stat-success { color: var(--success-600, #16a34a); }
-.wh-stat-failed { color: var(--danger-600, #dc2626); }
-.wh-stat-warning { color: var(--warning-600, #ca8a04); }
-
-.wh-delivery-bar {
-  display: flex;
-  height: 8px;
-  border-radius: 4px;
-  overflow: hidden;
-  background: var(--bg-tertiary);
-}
-
-.wh-delivery-segment {
-  transition: width 0.4s ease;
-  min-width: 0;
-}
-
-.wh-delivery-success { background: var(--success-500, #22c55e); }
-.wh-delivery-failed { background: var(--danger-500, #ef4444); }
-
-/* Volume chart */
-.volume-chart {
-  padding: 16px;
-}
-
-.volume-chart-bars {
-  display: flex;
-  align-items: flex-end;
-  gap: 4px;
-  height: 140px;
-  padding-bottom: 24px;
-  position: relative;
-}
-
-.volume-bar-group {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  height: 100%;
-  position: relative;
-}
-
-.volume-bar-stack {
-  flex: 1;
-  width: 100%;
-  max-width: 36px;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  position: relative;
-}
-
-.volume-bar {
-  width: 100%;
-  border-radius: 3px 3px 0 0;
-  min-width: 0;
-  transition: height 0.3s ease;
-}
-
-.volume-bar-sent {
-  background: var(--primary-500);
-}
-
-.volume-bar-failed {
-  background: var(--danger-400);
-  border-radius: 3px 3px 0 0;
-}
-
-.volume-bar-sent + .volume-bar-failed,
-.volume-bar-failed + .volume-bar-sent {
-  border-radius: 0;
-}
-
-.volume-bar-stack .volume-bar:first-child {
-  border-radius: 3px 3px 0 0;
-}
-
-.volume-bar-label {
-  position: absolute;
-  bottom: -22px;
-  font-size: 11px;
-  color: var(--text-muted);
-  white-space: nowrap;
-}
-
-.volume-chart-legend {
-  display: flex;
-  gap: 16px;
-  justify-content: center;
-  margin-top: 12px;
-}
-
-.volume-legend-item {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  color: var(--text-muted);
-}
-
-.volume-legend-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 2px;
-}
-
-.volume-legend-sent {
-  background: var(--primary-500);
-}
-
-.volume-legend-failed {
-  background: var(--danger-400);
+@media (prefers-reduced-motion: reduce) {
+  .skeleton { animation: none; }
 }
 </style>

--- a/web/src/views/dashboard/GettingStarted.vue
+++ b/web/src/views/dashboard/GettingStarted.vue
@@ -1,0 +1,213 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRouter } from "vue-router";
+import type { DashboardStats } from "../../api/types";
+
+const props = defineProps<{ stats: DashboardStats }>();
+const emit = defineEmits<{ dismiss: [] }>();
+const router = useRouter();
+
+const steps = computed(() => {
+  const s = props.stats;
+  const verifiedDomains = s.total_domains - s.unverified_domains;
+  return [
+    {
+      key: "domain",
+      label: "Verify a sending domain",
+      hint: "Prove ownership, then add SPF, DKIM, and DMARC records.",
+      done: verifiedDomains > 0,
+      to: "/domains",
+    },
+    {
+      key: "smtp",
+      label: "Connect an SMTP server",
+      hint: "Posta hands your mail to this server for delivery.",
+      done: s.total_smtp_servers > 0,
+      to: "/smtp-servers",
+    },
+    {
+      key: "key",
+      label: "Create an API key",
+      hint: "Scoped credentials your application sends with.",
+      done: s.total_api_keys > 0,
+      to: "/api-keys",
+    },
+    {
+      key: "send",
+      label: "Send your first email",
+      hint: "Through the API, the SMTP relay, or a template.",
+      done: s.total_emails > 0,
+      to: "/emails",
+    },
+  ];
+});
+
+const doneCount = computed(() => steps.value.filter((s) => s.done).length);
+const complete = computed(() => doneCount.value === steps.value.length);
+const nextStep = computed(() => steps.value.find((s) => !s.done));
+</script>
+
+<template>
+  <div v-if="!complete" class="card getting-started">
+    <div class="card-header">
+      <h2>Get Posta sending</h2>
+      <div class="gs-head-right">
+        <span class="gs-count">{{ doneCount }} of {{ steps.length }}</span>
+        <button class="gs-dismiss" type="button" title="Hide this checklist" @click="emit('dismiss')">
+          Dismiss
+        </button>
+      </div>
+    </div>
+    <div class="card-body">
+      <div class="gs-progress" role="progressbar" :aria-valuenow="doneCount" aria-valuemin="0" :aria-valuemax="steps.length">
+        <div class="gs-progress-fill" :style="{ width: `${(doneCount / steps.length) * 100}%` }"></div>
+      </div>
+
+      <ol class="gs-steps">
+        <li
+          v-for="step in steps"
+          :key="step.key"
+          class="gs-step"
+          :class="{ 'is-done': step.done, 'is-next': step.key === nextStep?.key }"
+        >
+          <span class="gs-mark" aria-hidden="true">
+            <svg v-if="step.done" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M3.5 8.5l3 3 6-7" />
+            </svg>
+          </span>
+          <span class="gs-body">
+            <span class="gs-label">{{ step.label }}</span>
+            <span class="gs-hint">{{ step.hint }}</span>
+          </span>
+          <button v-if="!step.done" class="btn btn-secondary btn-sm" @click="router.push(step.to)">
+            {{ step.key === nextStep?.key ? "Start" : "Open" }}
+          </button>
+        </li>
+      </ol>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.gs-head-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.gs-count {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.gs-dismiss {
+  border: 0;
+  background: none;
+  padding: 0;
+  font: inherit;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  cursor: pointer;
+}
+
+.gs-dismiss:hover {
+  color: var(--text-secondary);
+  text-decoration: underline;
+}
+
+.gs-progress {
+  height: 4px;
+  border-radius: 999px;
+  background: var(--bg-tertiary);
+  overflow: hidden;
+  margin-bottom: 18px;
+}
+
+.gs-progress-fill {
+  height: 100%;
+  background: var(--primary-500);
+  transition: width 0.3s ease;
+}
+
+.gs-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.gs-step {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-secondary);
+}
+
+.gs-step:last-child {
+  border-bottom: 0;
+}
+
+.gs-mark {
+  flex: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border-input);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-inverse);
+}
+
+.gs-mark svg {
+  width: 12px;
+  height: 12px;
+}
+
+.is-done .gs-mark {
+  background: var(--success-600);
+  border-color: var(--success-600);
+}
+
+.is-next .gs-mark {
+  border-color: var(--primary-500);
+  border-style: dashed;
+}
+
+.gs-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.gs-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.is-done .gs-label {
+  color: var(--text-tertiary);
+  text-decoration: line-through;
+}
+
+.gs-hint {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.is-done .gs-hint {
+  display: none;
+}
+
+.btn-sm {
+  padding: 5px 12px;
+  font-size: 12px;
+}
+</style>

--- a/web/src/views/dashboard/HealthAlerts.vue
+++ b/web/src/views/dashboard/HealthAlerts.vue
@@ -1,0 +1,167 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRouter } from "vue-router";
+import type { DashboardStats } from "../../api/types";
+
+const props = defineProps<{ stats: DashboardStats }>();
+const router = useRouter();
+
+interface Alert {
+  key: string;
+  tone: "danger" | "warning";
+  title: string;
+  detail: string;
+  action: string;
+  to: string;
+}
+
+const alerts = computed<Alert[]>(() => {
+  const s = props.stats;
+  const out: Alert[] = [];
+
+  if (s.unverified_domains > 0) {
+    out.push({
+      key: "domains",
+      tone: "warning",
+      title: `${s.unverified_domains} domain${s.unverified_domains === 1 ? "" : "s"} not verified`,
+      detail:
+        "Mail from an unverified domain is far more likely to be filtered, and some routes refuse to send from one at all.",
+      action: "Verify domains",
+      to: "/domains",
+    });
+  }
+
+  if (s.total_emails >= 20 && s.bounce_rate >= 5) {
+    out.push({
+      key: "bounces",
+      tone: "danger",
+      title: `Bounce rate is ${s.bounce_rate.toFixed(1)}%`,
+      detail:
+        "Sustained bounces above 5% damage sender reputation. Clean the recipient list before sending more.",
+      action: "Review bounces",
+      to: "/bounces",
+    });
+  }
+
+  if (s.total_emails >= 20 && s.failure_rate >= 10) {
+    out.push({
+      key: "failures",
+      tone: "danger",
+      title: `${s.failure_rate.toFixed(1)}% of sends are failing`,
+      detail:
+        "Check the SMTP server configuration and the most recent failures for a common cause.",
+      action: "View failed emails",
+      to: "/emails?status=failed",
+    });
+  }
+
+  if (s.expiring_api_keys > 0) {
+    out.push({
+      key: "keys",
+      tone: "warning",
+      title: `${s.expiring_api_keys} API key${s.expiring_api_keys === 1 ? "" : "s"} expiring within 7 days`,
+      detail: "Rotate them before they lapse, or the integrations using them will start failing.",
+      action: "Manage API keys",
+      to: "/api-keys",
+    });
+  }
+
+  if (s.features?.messages && s.unread_messages > 0) {
+    out.push({
+      key: "messages",
+      tone: "warning",
+      title: `${s.unread_messages} unread message${s.unread_messages === 1 ? "" : "s"}`,
+      detail: "Someone filled in one of your web forms and is waiting for a reply.",
+      action: "Open inbox",
+      to: "/messages",
+    });
+  }
+
+  return out;
+});
+
+defineExpose({ alerts });
+</script>
+
+<template>
+  <div v-if="alerts.length" class="alerts">
+    <div v-for="a in alerts" :key="a.key" class="alert-banner" :class="`alert-${a.tone}`" role="status">
+      <svg
+        class="ab-icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+        <line x1="12" y1="9" x2="12" y2="13" />
+        <line x1="12" y1="17" x2="12.01" y2="17" />
+      </svg>
+      <div class="ab-text">
+        <strong>{{ a.title }}</strong>
+        <span>{{ a.detail }}</span>
+      </div>
+      <button class="btn btn-secondary btn-sm" @click="router.push(a.to)">{{ a.action }}</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.alerts {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.alert-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: 1px solid;
+}
+
+.alert-danger {
+  background: var(--danger-50);
+  border-color: var(--danger-500);
+  color: var(--danger-600);
+}
+
+.alert-warning {
+  background: var(--warning-50);
+  border-color: var(--warning-500);
+  color: var(--warning-600);
+}
+
+.ab-icon {
+  width: 20px;
+  height: 20px;
+  flex: none;
+}
+
+.ab-text {
+  flex: 1;
+  min-width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.ab-text strong {
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.btn-sm {
+  padding: 5px 12px;
+  font-size: 12px;
+}
+</style>

--- a/web/src/views/dashboard/OverviewStats.vue
+++ b/web/src/views/dashboard/OverviewStats.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRouter } from "vue-router";
+import Sparkline from "../../components/Sparkline.vue";
+import type { DashboardStats } from "../../api/types";
+
+const props = defineProps<{ stats: DashboardStats }>();
+const router = useRouter();
+
+const sentSeries = computed(() => props.stats.daily_volume.map((d) => d.sent));
+const failedSeries = computed(() => props.stats.daily_volume.map((d) => d.failed));
+
+const deliveryRate = computed(() => {
+  const s = props.stats;
+  const attempted = s.sent_emails + s.failed_emails;
+  return attempted === 0 ? 0 : (s.sent_emails / attempted) * 100;
+});
+
+const inFlight = computed(() => props.stats.queued_emails + props.stats.processing_emails);
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
+  if (n >= 10_000) return (n / 1_000).toFixed(1) + "K";
+  return n.toLocaleString();
+}
+
+function deliveryTone(rate: number) {
+  if (rate >= 98) return "success";
+  if (rate >= 90) return "warning";
+  return "danger";
+}
+</script>
+
+<template>
+  <div class="stats-grid">
+    <button class="stat-card stat-clickable" @click="router.push('/emails')">
+      <div class="stat-header">
+        <div class="stat-label">Total emails</div>
+        <div class="stat-icon stat-icon-primary">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+        </div>
+      </div>
+      <div class="stat-value">{{ formatNumber(stats.total_emails) }}</div>
+      <Sparkline class="stat-spark" :values="sentSeries" :height="28" />
+    </button>
+
+    <button class="stat-card stat-clickable" @click="router.push('/analytics')">
+      <div class="stat-header">
+        <div class="stat-label">Delivery rate</div>
+        <div class="stat-icon" :class="`stat-icon-${deliveryTone(deliveryRate)}`">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
+        </div>
+      </div>
+      <div class="stat-value">{{ deliveryRate.toFixed(1) }}%</div>
+      <div class="stat-sub">{{ formatNumber(stats.sent_emails) }} delivered of {{ formatNumber(stats.sent_emails + stats.failed_emails) }} attempted</div>
+    </button>
+
+    <button
+      class="stat-card stat-clickable"
+      :class="{ 'stat-alert': stats.failed_emails > 0 && stats.failure_rate >= 10 }"
+      @click="router.push('/emails?status=failed')"
+    >
+      <div class="stat-header">
+        <div class="stat-label">Failed</div>
+        <div class="stat-icon stat-icon-danger">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
+        </div>
+      </div>
+      <div class="stat-value">{{ formatNumber(stats.failed_emails) }}</div>
+      <Sparkline class="stat-spark" :values="failedSeries" :height="28" stroke="var(--danger-500)" />
+    </button>
+
+    <button v-if="inFlight > 0" class="stat-card stat-clickable" @click="router.push('/emails?status=queued')">
+      <div class="stat-header">
+        <div class="stat-label">In flight</div>
+        <div class="stat-icon stat-icon-info">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        </div>
+      </div>
+      <div class="stat-value">{{ formatNumber(inFlight) }}</div>
+      <div class="stat-sub">{{ formatNumber(stats.queued_emails) }} queued · {{ formatNumber(stats.processing_emails) }} sending</div>
+    </button>
+
+    <button
+      v-if="stats.features?.messages"
+      class="stat-card stat-clickable"
+      :class="{ 'stat-alert': stats.unread_messages > 0 }"
+      @click="router.push('/messages')"
+    >
+      <div class="stat-header">
+        <div class="stat-label">Messages</div>
+        <div class="stat-icon stat-icon-primary">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+        </div>
+      </div>
+      <div class="stat-value">{{ formatNumber(stats.total_messages) }}</div>
+      <div class="stat-sub">
+        <span v-if="stats.unread_messages > 0" class="stat-sub-strong">{{ stats.unread_messages }} unread</span>
+        <span v-else>all read</span>
+        <span v-if="stats.spam_messages > 0"> · {{ formatNumber(stats.spam_messages) }} spam</span>
+      </div>
+    </button>
+
+    <button
+      v-if="stats.features?.inbound && stats.total_inbound > 0"
+      class="stat-card stat-clickable"
+      @click="router.push('/inbound-emails')"
+    >
+      <div class="stat-header">
+        <div class="stat-label">Inbound</div>
+        <div class="stat-icon stat-icon-info">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/><path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>
+        </div>
+      </div>
+      <div class="stat-value">{{ formatNumber(stats.total_inbound) }}</div>
+      <div class="stat-sub">{{ formatNumber(stats.forwarded_inbound) }} forwarded · {{ formatNumber(stats.failed_inbound) }} failed</div>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.stat-clickable {
+  display: block;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+  transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+}
+
+.stat-clickable:hover {
+  border-color: var(--border-input);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.stat-clickable:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+
+.stat-alert {
+  border-color: var(--warning-500);
+}
+
+.stat-spark {
+  margin-top: 10px;
+  width: 100%;
+}
+
+.stat-sub-strong {
+  color: var(--warning-600);
+  font-weight: 600;
+}
+</style>

--- a/web/src/views/dashboard/QuickActions.vue
+++ b/web/src/views/dashboard/QuickActions.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRouter } from "vue-router";
+import type { DashboardFeatures } from "../../api/types";
+
+const props = defineProps<{ features?: DashboardFeatures | null }>();
+
+const router = useRouter();
+
+const actions = computed(() => {
+  const items = [
+    { to: "/emails", icon: "send", label: "Send an email", hint: "Compose or replay a message", tone: "primary" },
+    { to: "/templates", icon: "file-text", label: "New template", hint: "Reusable, versioned, localizable", tone: "primary" },
+    { to: "/campaigns", icon: "mail", label: "New campaign", hint: "Send to a subscriber list", tone: "primary" },
+    { to: "/domains", icon: "globe", label: "Add domain", hint: "Verify ownership, SPF, DKIM, DMARC", tone: "success" },
+    { to: "/api-keys", icon: "key", label: "Create API key", hint: "Scoped credentials for your app", tone: "info" },
+    { to: "/webhooks", icon: "link", label: "Add webhook", hint: "Receive delivery events", tone: "info" },
+  ];
+  if (props.features?.messages) {
+    items.splice(3, 0, {
+      to: "/forms",
+      icon: "edit-3",
+      label: "New form",
+      hint: "Receive messages from your website",
+      tone: "primary",
+    });
+  }
+  return items;
+});
+
+const icons: Record<string, string> = {
+  send: '<path d="M16.5 1.5L8.25 9.75M16.5 1.5l-5.25 15-3-6.75L1.5 6.75l15-5.25z"/>',
+  "file-text": '<path d="M10.5 1.5H4.5a1.5 1.5 0 00-1.5 1.5v12a1.5 1.5 0 001.5 1.5h9a1.5 1.5 0 001.5-1.5V6l-4.5-4.5z"/><path d="M10.5 1.5V6H15"/>',
+  mail: '<rect x="2" y="3.5" width="14" height="11" rx="2"/><path d="M2 5.5l7 5 7-5"/>',
+  globe: '<circle cx="9" cy="9" r="7"/><path d="M2 9h14M9 2a11 11 0 013 7 11 11 0 01-3 7 11 11 0 01-3-7 11 11 0 013-7z"/>',
+  key: '<path d="M15.5 2.5l-2 2m1 1l-2 2-3-3 2-2m-3.18 3.18a4 4 0 10-5.64 5.64 4 4 0 005.64-5.64z"/>',
+  link: '<path d="M7.5 10.5a3.75 3.75 0 005.3.45l2.25-2.25a3.75 3.75 0 00-5.3-5.3l-1.29 1.28"/><path d="M10.5 7.5a3.75 3.75 0 00-5.3-.45L2.96 9.3a3.75 3.75 0 005.3 5.3l1.28-1.28"/>',
+  "edit-3": '<path d="M12 2.25l3.75 3.75L6 15.75H2.25V12L12 2.25z"/>',
+};
+</script>
+
+<template>
+  <div class="quick-actions">
+    <button
+      v-for="a in actions"
+      :key="a.to"
+      class="qa"
+      :class="`qa-${a.tone}`"
+      :title="a.hint"
+      @click="router.push(a.to)"
+    >
+      <svg
+        class="qa-icon"
+        width="16"
+        height="16"
+        viewBox="0 0 18 18"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+        v-html="icons[a.icon]"
+      ></svg>
+      <span>{{ a.label }}</span>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.qa {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 13px 7px 10px;
+  border-radius: 8px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, transform 0.15s;
+}
+
+.qa:hover {
+  border-color: var(--qa-color);
+  background: var(--bg-hover);
+  transform: translateY(-1px);
+}
+
+.qa-icon {
+  flex: none;
+  color: var(--qa-color);
+}
+
+.qa-primary { --qa-color: var(--primary-500); }
+.qa-success { --qa-color: var(--success-600); }
+.qa-info { --qa-color: var(--primary-400); }
+
+@media (max-width: 719px) {
+  .quick-actions {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+    padding-bottom: 2px;
+  }
+  .quick-actions::-webkit-scrollbar {
+    display: none;
+  }
+  .qa {
+    flex: 0 0 auto;
+  }
+}
+</style>

--- a/web/src/views/dashboard/RecentEmails.vue
+++ b/web/src/views/dashboard/RecentEmails.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { useRouter } from "vue-router";
+import type { Email } from "../../api/types";
+
+defineProps<{ emails: Email[] }>();
+const router = useRouter();
+
+function statusBadgeClass(status: string) {
+  switch (status) {
+    case "sent":
+      return "badge badge-success";
+    case "failed":
+      return "badge badge-danger";
+    case "pending":
+    case "processing":
+      return "badge badge-warning";
+    case "queued":
+    case "scheduled":
+      return "badge badge-info";
+    case "suppressed":
+      return "badge badge-secondary";
+    default:
+      return "badge";
+  }
+}
+
+function relativeTime(date: string | null) {
+  if (!date) return "-";
+  const then = new Date(date).getTime();
+  if (Number.isNaN(then)) return "-";
+  const secs = Math.floor((Date.now() - then) / 1000);
+  if (secs < 60) return `${Math.max(0, secs)}s ago`;
+  if (secs < 3600) return `${Math.floor(secs / 60)}m ago`;
+  if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`;
+  return `${Math.floor(secs / 86400)}d ago`;
+}
+</script>
+
+<template>
+  <div class="card">
+    <div class="card-header">
+      <h2>Recent emails</h2>
+      <button class="btn btn-secondary btn-sm" @click="router.push('/emails')">View all</button>
+    </div>
+
+    <div v-if="!emails.length" class="empty-state">
+      <h3>No emails yet</h3>
+      <p>Messages you send through the API, the relay, or a campaign appear here.</p>
+    </div>
+
+    <div v-else class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Recipient</th>
+            <th>Subject</th>
+            <th>Status</th>
+            <th>Sent</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="email in emails"
+            :key="email.uuid"
+            style="cursor: pointer"
+            @click="router.push(`/emails/${email.uuid}`)"
+          >
+            <td class="cell-truncate">{{ email.recipients?.join(", ") || "-" }}</td>
+            <td class="cell-truncate">{{ email.subject || "(no subject)" }}</td>
+            <td><span :class="statusBadgeClass(email.status)">{{ email.status }}</span></td>
+            <td :title="email.sent_at || email.created_at">
+              {{ relativeTime(email.sent_at || email.created_at) }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.btn-sm {
+  padding: 5px 12px;
+  font-size: 12px;
+}
+
+.cell-truncate {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/web/src/views/dashboard/ResourceCards.vue
+++ b/web/src/views/dashboard/ResourceCards.vue
@@ -1,0 +1,225 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRouter } from "vue-router";
+import type { DashboardStats } from "../../api/types";
+
+const props = defineProps<{ stats: DashboardStats }>();
+const router = useRouter();
+
+interface Row {
+  label: string;
+  value: string;
+  secondary?: string;
+  tone?: "danger" | "warning";
+  to?: string;
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
+  if (n >= 10_000) return (n / 1_000).toFixed(1) + "K";
+  return n.toLocaleString();
+}
+
+const infrastructure = computed<Row[]>(() => {
+  const s = props.stats;
+  const rows: Row[] = [
+    {
+      label: "Domains",
+      value: String(s.total_domains - s.unverified_domains),
+      secondary: `of ${s.total_domains} verified`,
+      tone: s.unverified_domains > 0 ? "warning" : undefined,
+      to: "/domains",
+    },
+    {
+      label: "API keys",
+      value: String(s.active_api_keys),
+      secondary: `of ${s.total_api_keys} active`,
+      tone: s.expiring_api_keys > 0 ? "warning" : undefined,
+      to: "/api-keys",
+    },
+    { label: "SMTP servers", value: String(s.total_smtp_servers), to: "/smtp-servers" },
+    { label: "Webhooks", value: String(s.total_webhooks), to: "/webhooks" },
+    { label: "Templates", value: String(s.total_templates), to: "/templates" },
+  ];
+  if (s.features?.messages) {
+    rows.push({ label: "Forms", value: String(s.total_forms), to: "/forms" });
+  }
+  return rows;
+});
+
+const deliverability = computed<Row[]>(() => {
+  const s = props.stats;
+  return [
+    {
+      label: "Bounces",
+      value: formatNumber(s.total_bounces),
+      secondary: s.total_emails > 0 ? `${s.bounce_rate.toFixed(1)}% of sends` : undefined,
+      tone: s.bounce_rate >= 5 && s.total_emails >= 20 ? "danger" : undefined,
+      to: "/bounces",
+    },
+    { label: "Suppressions", value: formatNumber(s.total_suppressions), to: "/bounces" },
+    { label: "Suppressed sends", value: formatNumber(s.suppressed_emails) },
+    { label: "Contacts", value: formatNumber(s.total_contacts), to: "/contacts" },
+    { label: "Subscribers", value: formatNumber(s.total_subscribers), to: "/subscribers" },
+    { label: "Campaigns", value: formatNumber(s.total_campaigns), to: "/campaigns" },
+  ];
+});
+
+const webhookHealth = computed(() => props.stats.webhook_deliveries);
+</script>
+
+<template>
+  <div class="card">
+    <div class="card-header"><h2>Infrastructure</h2></div>
+    <ul class="res-list">
+      <li
+        v-for="row in infrastructure"
+        :key="row.label"
+        class="res-row"
+        :class="{ 'is-clickable': !!row.to }"
+        @click="row.to && router.push(row.to)"
+      >
+        <span class="res-label">{{ row.label }}</span>
+        <span class="res-value" :class="row.tone ? `tone-${row.tone}` : ''">
+          {{ row.value }}
+          <small v-if="row.secondary">{{ row.secondary }}</small>
+        </span>
+      </li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <div class="card-header"><h2>Deliverability</h2></div>
+    <ul class="res-list">
+      <li
+        v-for="row in deliverability"
+        :key="row.label"
+        class="res-row"
+        :class="{ 'is-clickable': !!row.to }"
+        @click="row.to && router.push(row.to)"
+      >
+        <span class="res-label">{{ row.label }}</span>
+        <span class="res-value" :class="row.tone ? `tone-${row.tone}` : ''">
+          {{ row.value }}
+          <small v-if="row.secondary">{{ row.secondary }}</small>
+        </span>
+      </li>
+    </ul>
+  </div>
+
+  <div v-if="webhookHealth && webhookHealth.total_deliveries > 0" class="card">
+    <div class="card-header">
+      <h2>Webhook deliveries</h2>
+      <button class="btn btn-secondary btn-sm" @click="router.push('/webhook-deliveries')">Details</button>
+    </div>
+    <div class="card-body">
+      <div class="wh-head">
+        <span
+          class="wh-rate"
+          :class="webhookHealth.success_rate >= 95 ? 'tone-ok' : webhookHealth.success_rate >= 80 ? 'tone-warning' : 'tone-danger'"
+        >{{ webhookHealth.success_rate.toFixed(1) }}%</span>
+        <span class="wh-sub">
+          {{ formatNumber(webhookHealth.success_deliveries) }} delivered ·
+          {{ formatNumber(webhookHealth.failed_deliveries) }} failed
+        </span>
+      </div>
+      <div class="wh-bar">
+        <span class="wh-seg wh-ok" :style="{ width: `${webhookHealth.success_rate}%` }"></span>
+        <span class="wh-seg wh-bad" :style="{ width: `${100 - webhookHealth.success_rate}%` }"></span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.res-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 24px 8px;
+}
+
+.res-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 11px 0;
+  border-bottom: 1px solid var(--border-secondary);
+}
+
+.res-row:last-child {
+  border-bottom: 0;
+}
+
+.is-clickable {
+  cursor: pointer;
+  margin: 0 -12px;
+  padding-left: 12px;
+  padding-right: 12px;
+  border-radius: 6px;
+}
+
+.is-clickable:hover {
+  background: var(--bg-hover);
+}
+
+.res-label {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.res-value {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.res-value small {
+  display: block;
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-tertiary);
+}
+
+.tone-warning { color: var(--warning-600); }
+.tone-danger { color: var(--danger-600); }
+.tone-ok { color: var(--success-600); }
+
+.wh-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.wh-rate {
+  font-size: 24px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.wh-sub {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.wh-bar {
+  display: flex;
+  height: 6px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: var(--bg-tertiary);
+}
+
+.wh-seg { display: block; }
+.wh-ok { background: var(--success-500); }
+.wh-bad { background: var(--danger-500); }
+
+.btn-sm {
+  padding: 5px 12px;
+  font-size: 12px;
+}
+</style>

--- a/web/src/views/dashboard/VolumeChart.vue
+++ b/web/src/views/dashboard/VolumeChart.vue
@@ -1,0 +1,289 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import type { DailyVolume } from "../../api/types";
+
+const props = defineProps<{ volume: DailyVolume[] }>();
+
+const hovered = ref<number | null>(null);
+
+const totals = computed(() => {
+  let sent = 0;
+  let failed = 0;
+  for (const d of props.volume) {
+    sent += d.sent;
+    failed += d.failed;
+  }
+  return { sent, failed, total: sent + failed };
+});
+
+const NICE_STEPS = [1, 1.25, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10];
+
+const peak = computed(() => {
+  const max = Math.max(0, ...props.volume.map((d) => d.sent + d.failed));
+  if (max === 0) return 0;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(max)));
+  const ratio = max / magnitude;
+  const step = NICE_STEPS.find((n) => n >= ratio) ?? 10;
+  return Math.round(step * magnitude);
+});
+
+const busiest = computed(() => {
+  let best: DailyVolume | null = null;
+  for (const d of props.volume) {
+    if (!best || d.sent + d.failed > best.sent + best.failed) best = d;
+  }
+  return best;
+});
+
+function heightPct(value: number) {
+  if (peak.value === 0) return "0%";
+  const pct = (value / peak.value) * 100;
+  return `${value > 0 ? Math.max(pct, 1.5) : 0}%`;
+}
+
+function dayLabel(dateStr: string) {
+  return new Date(dateStr + "T00:00:00").toLocaleDateString(undefined, {
+    weekday: "short",
+  });
+}
+
+function fullDate(dateStr: string) {
+  return new Date(dateStr + "T00:00:00").toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function showAxisLabel(idx: number) {
+  return idx === 0 || idx === props.volume.length - 1 || idx % 3 === 0;
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
+  if (n >= 10_000) return (n / 1_000).toFixed(1) + "K";
+  return n.toLocaleString();
+}
+</script>
+
+<template>
+  <div class="card">
+    <div class="card-header">
+      <h2>Send volume</h2>
+      <div class="vc-summary">
+        <span>Last {{ volume.length }} days</span>
+        <span class="vc-dot">·</span>
+        <strong>{{ formatNumber(totals.total) }}</strong>
+        <span v-if="busiest && totals.total > 0" class="vc-peak">
+          peak {{ formatNumber(busiest.sent + busiest.failed) }} on {{ fullDate(busiest.date) }}
+        </span>
+      </div>
+    </div>
+
+    <div class="card-body">
+      <div v-if="totals.total === 0" class="empty-state vc-empty">
+        <h3>No sends in this window</h3>
+        <p>Volume appears here once emails start going out.</p>
+      </div>
+
+      <div v-else class="vc">
+        <div class="vc-axis" aria-hidden="true">
+          <span>{{ formatNumber(peak) }}</span>
+          <span>{{ formatNumber(Math.round(peak / 2)) }}</span>
+          <span>0</span>
+        </div>
+
+        <div class="vc-plot">
+          <div class="vc-grid" aria-hidden="true">
+            <span></span><span></span><span></span>
+          </div>
+
+          <div class="vc-bars">
+            <div
+              v-for="(day, idx) in volume"
+              :key="day.date"
+              class="vc-col"
+              :class="{ 'is-hovered': hovered === idx }"
+              @mouseenter="hovered = idx"
+              @mouseleave="hovered = null"
+            >
+              <div class="vc-stack">
+                <div class="vc-bar vc-bar-failed" :style="{ height: heightPct(day.failed) }"></div>
+                <div class="vc-bar vc-bar-sent" :style="{ height: heightPct(day.sent) }"></div>
+              </div>
+
+              <div v-if="hovered === idx" class="vc-tip" role="tooltip">
+                <strong>{{ fullDate(day.date) }}</strong>
+                <span><i class="vc-key vc-key-sent"></i>{{ day.sent.toLocaleString() }} sent</span>
+                <span><i class="vc-key vc-key-failed"></i>{{ day.failed.toLocaleString() }} failed</span>
+              </div>
+
+              <div class="vc-label">{{ showAxisLabel(idx) ? dayLabel(day.date) : "" }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="totals.total > 0" class="vc-legend">
+        <span><i class="vc-key vc-key-sent"></i>Sent {{ formatNumber(totals.sent) }}</span>
+        <span><i class="vc-key vc-key-failed"></i>Failed {{ formatNumber(totals.failed) }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.vc-summary {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.vc-summary strong {
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.vc-dot { opacity: 0.6; }
+.vc-peak { font-size: 12px; }
+.vc-empty { padding: 36px 16px; }
+
+.vc {
+  display: flex;
+  gap: 10px;
+}
+
+.vc-axis {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 160px;
+  font-size: 10px;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+  padding-bottom: 18px;
+  text-align: right;
+  min-width: 28px;
+}
+
+.vc-plot {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.vc-grid {
+  position: absolute;
+  inset: 0 0 18px 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;
+}
+
+.vc-grid span {
+  height: 1px;
+  background: var(--border-secondary);
+}
+
+.vc-bars {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  height: 160px;
+}
+
+.vc-col {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.vc-stack {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.vc-col.is-hovered .vc-stack {
+  outline: 1px solid var(--border-input);
+  outline-offset: 1px;
+}
+
+.vc-bar {
+  width: 100%;
+  transition: height 0.25s ease;
+}
+
+.vc-bar-sent { background: var(--primary-500); }
+.vc-bar-failed { background: var(--danger-500); }
+
+.vc-label {
+  height: 18px;
+  line-height: 18px;
+  text-align: center;
+  font-size: 10px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.vc-tip {
+  position: absolute;
+  bottom: calc(100% - 12px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  box-shadow: var(--shadow-lg);
+  font-size: 11px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.vc-tip strong {
+  color: var(--text-primary);
+  font-size: 12px;
+}
+
+.vc-legend {
+  display: flex;
+  gap: 16px;
+  margin-top: 14px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.vc-legend span,
+.vc-tip span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.vc-key {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex: none;
+}
+
+.vc-key-sent { background: var(--primary-500); }
+.vc-key-failed { background: var(--danger-500); }
+</style>


### PR DESCRIPTION
Both pages showed numbers and left the reader to work out whether anything was wrong. They now lead with a derived verdict and the actions that follow from it.
Workspace dashboard:
- Greeting, workspace context, and a health pill derived from delivery and configuration state rather than asserted.
- Actionable banners for unverified domains, bounce rate above 5%, failure rate above 10%, expiring keys, and unread form messages. Each names the consequence and links to the fix.
- A getting-started checklist that ticks itself off real resources and disappears once sending works. Dismissible.
- Quick actions, clickable stat cards with sparklines, and a messages tile.
- Send volume chart gains a y-axis on a 1/1.25/1.5/2/2.5-style scale, grid lines, per-day tooltips, dated peak, and an empty state.
- Skeletons instead of a spinner, a 60s refresh that pauses when the tab is hidden, and a visible last-updated stamp.
- Split from one 534-line file into an orchestrator plus seven components.

Admin metrics:
- A health card that derives Operational/Degraded/Needs attention from worker connectivity, migration backlog, delivery rate, 2FA adoption, worker version skew, and failed sign-ins, and lists the reasons.
- Ratio meters with warn/crit levels and hints, replacing bare percentages.
- Runtime tiles with sparklines fed from the existing SSE stream, which was already pushing samples that were being thrown away.
- Quick links to the admin sections and errors via the notification store rather than console.error.