### PR TITLE
feat(workspaces): seed starter content on every new workspace, opt-out

### DIFF
--- a/cmd/posta/server.go
+++ b/cmd/posta/server.go
@@ -91,13 +91,14 @@ func runServer(cli *okapicli.CLI) {
 
 			seedDefaults(res.db, cfg)
 
-			// The system workspace needs an administrator to own it, so it is
-			// ensured after seeding rather than in the migration step, which may
-			// run before any admin exists.
-			if _, err := workspacesvc.EnsureSystem(res.db, cfg.SystemSMTP); err != nil {
+			if ws, err := workspacesvc.EnsureSystem(res.db, cfg.SystemSMTP); err != nil {
 				logger.Error("failed to ensure the system workspace", "error", err)
-			} else if err := workspacesvc.SyncMembers(res.db); err != nil {
-				logger.Error("failed to sync system workspace members", "error", err)
+			} else {
+
+				seedWorkspace(res.db, ws.ID, ws.OwnerID)
+				if err := workspacesvc.SyncMembers(res.db); err != nil {
+					logger.Error("failed to sync system workspace members", "error", err)
+				}
 			}
 
 			// Initialize blob storage (S3 or filesystem) for attachments
@@ -212,19 +213,33 @@ func checkDefaultPlan(db *gorm.DB, cfg *config.Config) {
 	}
 }
 
-func seedDefaults(db *gorm.DB, cfg *config.Config) {
-	userRepo := repositories.NewUserRepository(db)
-	admin, err := userRepo.FindByEmail(cfg.AdminEmail)
-	if err != nil || admin == nil {
-		return
-	}
-	s := seeder.New(
+// newSeeder builds the default-content seeder. Cheap to construct: it holds
+// repositories and no state, so callers make one rather than threading it.
+func newSeeder(db *gorm.DB) *seeder.Seeder {
+	return seeder.New(
 		repositories.NewTemplateRepository(db),
 		repositories.NewStyleSheetRepository(db),
 		repositories.NewTemplateVersionRepository(db),
 		repositories.NewTemplateLocalizationRepository(db),
 		repositories.NewLanguageRepository(db),
 	)
+}
+
+func seedWorkspace(db *gorm.DB, workspaceID, ownerID uint) {
+	ownerName := ""
+	if owner, err := repositories.NewUserRepository(db).FindByID(ownerID); err == nil && owner != nil {
+		ownerName = owner.Name
+	}
+	newSeeder(db).SeedWorkspaceDefaults(workspaceID, ownerID, ownerName)
+}
+
+func seedDefaults(db *gorm.DB, cfg *config.Config) {
+	userRepo := repositories.NewUserRepository(db)
+	admin, err := userRepo.FindByEmail(cfg.AdminEmail)
+	if err != nil || admin == nil {
+		return
+	}
+	s := newSeeder(db)
 	migrator := workspaceprovision.New(cfg.PlanEnforcement)
 	migrator.SetSeeder(s)
 	if _, err := migrator.EnsureWorkspace(db, admin.ID); err != nil {

--- a/cmd/posta/worker.go
+++ b/cmd/posta/worker.go
@@ -25,7 +25,9 @@ import (
 
 func runWorker() error {
 	cfg := config.New()
-	_ = cfg.InitWorker()
+	if err := cfg.InitWorker(); err != nil {
+		logger.Fatal("worker configuration is not usable", "error", err)
+	}
 	cfg.InitStorage()
 
 	db := cfg.Database.DB

--- a/docs/docs/workspaces/overview.md
+++ b/docs/docs/workspaces/overview.md
@@ -150,11 +150,16 @@ Request body:
   "name": "Acme Inc",
   "slug": "acme",
   "description": "Marketing and transactional mail",
-  "default_language": "en"
+  "default_language": "en",
+  "seed_defaults": true
 }
 ```
 
 Only `name` is required. If `slug` is omitted it is derived from the name; slugs must contain only lowercase letters, numbers, and hyphens, and must be unique. `default_language` defaults to `en`. The caller becomes the workspace **owner**.
+
+`seed_defaults` controls whether the new workspace starts with content: a welcome template in English, French and German, a default stylesheet, and the matching languages. It defaults to `true`, so omitting it gives you a workspace you can send from immediately. Send `false` when you intend to populate the workspace from an [export](../gdpr/data-export-import.md) or the API and do not want the starter template in the way.
+
+Seeding is best effort and runs after the workspace exists, so a workspace is never left uncreated because its starter content failed.
 
 ```bash
 curl -X POST http://localhost:9000/api/v1/workspaces \

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -367,9 +367,8 @@ func (c *Config) validate() error {
 	return c.ValidateSecurity()
 }
 func (c *Config) validateWorker() error {
-	// The worker verifies the same JWTs the server issues, so it needs the same
-	// secret to be real.
-	return c.ValidateSecurity()
+	warnRemovedEnvVars()
+	return c.ValidateWorker()
 }
 func (c *Config) Initialize(app *okapi.Okapi) error {
 	if err := c.validate(); err != nil {
@@ -447,11 +446,8 @@ func (c *Config) Initialize(app *okapi.Okapi) error {
 func (c *Config) InitWorker() error {
 	// Initialize global logger
 	c.initLogger()
-	c.WarnInsecureConfig()
-	if err := c.validateWorker(); err != nil {
-		return err
-	}
-	return nil
+	c.WarnInsecureWorkerConfig()
+	return c.validateWorker()
 }
 func (c *Config) initLogger() *logger.Logger {
 	if c.DevMode {

--- a/internal/config/security.go
+++ b/internal/config/security.go
@@ -97,15 +97,17 @@ func (c *Config) adminPasswordProblem() *secretProblem {
 	return nil
 }
 
-// securityProblems collects every unacceptable value in one pass so an operator
-// fixing their configuration sees the whole list rather than one item per boot.
-func (c *Config) securityProblems() []secretProblem {
+// sharedSecretProblems are the values both binaries depend on.
+//
+// The worker signs tracking links and stamps outgoing mail with the same JWT
+// secret the server uses, and it is the process that decrypts a stored SMTP
+// password at send time. A worker configured differently from its server does
+// not fail loudly; it produces links the server rejects and credentials it
+// cannot read.
+func (c *Config) sharedSecretProblems() []secretProblem {
 	var problems []secretProblem
 
 	if p := c.jwtSecretProblem(); p != nil {
-		problems = append(problems, *p)
-	}
-	if p := c.adminPasswordProblem(); p != nil {
 		problems = append(problems, *p)
 	}
 	if strings.TrimSpace(c.EncryptionKey) == "" {
@@ -114,6 +116,19 @@ func (c *Config) securityProblems() []secretProblem {
 			"is unset, so stored SMTP credentials fall back to base64 encoding, which is reversible",
 			false,
 		})
+	}
+	return problems
+}
+
+// securityProblems collects every unacceptable value in one pass so an operator
+// fixing their configuration sees the whole list rather than one item per boot.
+// This is the server's set: it includes the values only a process serving HTTP
+// and seeding the first admin can act on.
+func (c *Config) securityProblems() []secretProblem {
+	problems := c.sharedSecretProblems()
+
+	if p := c.adminPasswordProblem(); p != nil {
+		problems = append(problems, *p)
 	}
 	if strings.TrimSpace(c.CORSOrigins) == "*" {
 		problems = append(problems, secretProblem{
@@ -131,6 +146,77 @@ func (c *Config) securityProblems() []secretProblem {
 	}
 
 	return problems
+}
+
+// workerProblems is the worker's set. It drops the checks the worker cannot
+// act on — it seeds no admin, serves no HTTP, and exposes no form endpoint —
+// and adds the ones that decide whether it will do any work at all.
+func (c *Config) workerProblems() []secretProblem {
+	problems := c.sharedSecretProblems()
+
+	if c.Redis.Addr == "" && c.Redis.URL == "" {
+		problems = append(problems, secretProblem{
+			"POSTA_REDIS_ADDR",
+			"is empty, so the worker has no queue to consume and will process nothing",
+			true,
+		})
+	}
+	if c.WorkerConcurrency <= 0 {
+		problems = append(problems, secretProblem{
+			"POSTA_WORKER_CONCURRENCY",
+			fmt.Sprintf("is %d, so the worker would start and process nothing", c.WorkerConcurrency),
+			true,
+		})
+	}
+	if c.WorkerMaxRetries < 0 {
+		problems = append(problems, secretProblem{
+			"POSTA_WORKER_MAX_RETRIES",
+			fmt.Sprintf("is %d; it cannot be negative", c.WorkerMaxRetries),
+			true,
+		})
+	}
+	if c.MessagesEnabled && !c.SystemSMTP.IsConfigured() {
+		problems = append(problems, secretProblem{
+			"POSTA_SYSTEM_SMTP_HOST",
+			"is unset while web form messages are enabled, so the worker cannot deliver the notification for a submission",
+			false,
+		})
+	}
+	return problems
+}
+
+// ValidateWorker refuses to start a production worker whose configuration
+// contains a fatal problem, and reports the rest. The two fatal worker checks
+// are fatal everywhere, not only in production: a worker with no queue or no
+// concurrency is not a degraded worker, it is a process that looks healthy and
+// silently does nothing.
+func (c *Config) ValidateWorker() error {
+	for _, p := range c.workerProblems() {
+		if !p.fatal {
+			continue
+		}
+		if p.envVar == envJWTSecret && !c.IsProduction() {
+			continue
+		}
+		return fmt.Errorf("%s %s", p.envVar, p.reason)
+	}
+	return nil
+}
+
+// WarnInsecureWorkerConfig logs the worker's advisory problems once the logger
+// exists, mirroring WarnInsecureConfig for the server.
+func (c *Config) WarnInsecureWorkerConfig() {
+	for _, p := range c.workerProblems() {
+		if p.fatal && c.IsProduction() {
+			continue
+		}
+		msg := p.envVar + " " + p.reason
+		if p.fatal {
+			logger.Warn("worker configuration: "+msg, "env", p.envVar)
+			continue
+		}
+		logger.Warn("worker configuration: "+msg, "env", p.envVar)
+	}
 }
 
 // ValidateSecurity refuses to start a production deployment whose configuration

--- a/internal/config/security_test.go
+++ b/internal/config/security_test.go
@@ -218,3 +218,115 @@ func hasProblem(problems []secretProblem, envVar string) bool {
 	}
 	return false
 }
+
+func workerConfig() *Config {
+	return &Config{
+		Env:               "production",
+		JWTSecret:         strings.Repeat("a", MinJWTSecretLength),
+		EncryptionKey:     strings.Repeat("b", 32),
+		WorkerConcurrency: 10,
+		WorkerMaxRetries:  5,
+		Redis:             RedisConfig{Addr: "localhost:6379"},
+	}
+}
+
+func TestValidateWorkerAcceptsAUsableConfig(t *testing.T) {
+	if err := workerConfig().ValidateWorker(); err != nil {
+		t.Fatalf("ValidateWorker: %v", err)
+	}
+}
+
+// A worker with no queue or no concurrency is not degraded, it is a process
+// that looks healthy and silently does nothing, so these refuse outside
+// production too.
+func TestValidateWorkerRefusesAWorkerThatCannotWork(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Config)
+		want   string
+	}{
+		{"no queue", func(c *Config) { c.Redis = RedisConfig{} }, "POSTA_REDIS_ADDR"},
+		{"zero concurrency", func(c *Config) { c.WorkerConcurrency = 0 }, "POSTA_WORKER_CONCURRENCY"},
+		{"negative concurrency", func(c *Config) { c.WorkerConcurrency = -1 }, "POSTA_WORKER_CONCURRENCY"},
+		{"negative retries", func(c *Config) { c.WorkerMaxRetries = -1 }, "POSTA_WORKER_MAX_RETRIES"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, env := range []string{"production", "dev"} {
+				cfg := workerConfig()
+				cfg.Env = env
+				tc.mutate(cfg)
+
+				err := cfg.ValidateWorker()
+				if err == nil {
+					t.Fatalf("env=%s: expected a refusal", env)
+				}
+				if !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("env=%s: error %q does not name %s", env, err, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// A Redis URL is an alternative to the discrete address, not a missing one.
+func TestValidateWorkerAcceptsARedisURL(t *testing.T) {
+	cfg := workerConfig()
+	cfg.Redis = RedisConfig{URL: "redis://localhost:6379/0"}
+
+	if err := cfg.ValidateWorker(); err != nil {
+		t.Fatalf("ValidateWorker: %v", err)
+	}
+}
+
+// The worker seeds no admin, serves no HTTP, and exposes no form endpoint, so
+// none of those should be able to stop it starting or clutter its logs.
+func TestWorkerProblemsDropServerOnlyChecks(t *testing.T) {
+	cfg := workerConfig()
+	cfg.AdminPassword = "admin1234"
+	cfg.CORSOrigins = "*"
+	cfg.MessagesEnabled = true
+	cfg.MessagesIPRateLimit = 0
+	cfg.SystemSMTP = SystemSMTPConfig{Host: "smtp.example.com", From: "a@b.com"}
+
+	for _, p := range cfg.workerProblems() {
+		switch p.envVar {
+		case "POSTA_ADMIN_PASSWORD", "POSTA_CORS_ORIGINS", "POSTA_MESSAGES_IP_RATE_LIMIT":
+			t.Fatalf("worker should not be checked for %s", p.envVar)
+		}
+	}
+
+	// The same values must still reach the server's list.
+	var sawCORS bool
+	for _, p := range cfg.securityProblems() {
+		if p.envVar == "POSTA_CORS_ORIGINS" {
+			sawCORS = true
+		}
+	}
+	if !sawCORS {
+		t.Fatal("the server must still be warned about a wildcard CORS policy")
+	}
+}
+
+// Messages are processed by the worker, and their notification needs system
+// SMTP. Advisory, not fatal: the submission is still stored.
+func TestWorkerWarnsWhenMessagesHaveNoNotificationPath(t *testing.T) {
+	cfg := workerConfig()
+	cfg.MessagesEnabled = true
+
+	var found bool
+	for _, p := range cfg.workerProblems() {
+		if p.envVar == "POSTA_SYSTEM_SMTP_HOST" {
+			found = true
+			if p.fatal {
+				t.Fatal("a missing notification path must not stop the worker")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected a warning about the missing system SMTP")
+	}
+	if err := cfg.ValidateWorker(); err != nil {
+		t.Fatalf("ValidateWorker should still pass: %v", err)
+	}
+}

--- a/internal/handlers/workspace_handler.go
+++ b/internal/handlers/workspace_handler.go
@@ -28,6 +28,13 @@ type WorkspaceHandler struct {
 	notifier      *notification.Service
 	appURL        string
 	audit         *audit.Logger
+	seeder        workspaceSeeder
+}
+
+// workspaceSeeder fills a new workspace with the default templates, stylesheet,
+// and languages. Optional: without one, workspaces are simply created empty.
+type workspaceSeeder interface {
+	SeedWorkspaceDefaults(workspaceID, userID uint, userName string)
 }
 
 // planService is an optional interface for resolving workspace plans and quotas.
@@ -44,12 +51,22 @@ func NewWorkspaceHandler(workspaceRepo *repositories.WorkspaceRepository, userRe
 	}
 }
 
+// SetSeeder enables starter content on newly created workspaces. Without one,
+// workspaces are created empty and the seed_defaults flag has no effect.
+func (h *WorkspaceHandler) SetSeeder(s workspaceSeeder) { h.seeder = s }
+
 type CreateWorkspaceRequest struct {
 	Body struct {
 		Name            string `json:"name" required:"true" minLength:"1"`
 		Slug            string `json:"slug"`
 		Description     string `json:"description"`
 		DefaultLanguage string `json:"default_language"`
+		// SeedDefaults fills the new workspace with starter templates, a
+		// stylesheet, and languages. Omitted means yes: an empty workspace has
+		// nothing to send and nothing to look at, which is rarely what someone
+		// creating one wants. Send false for a workspace you intend to populate
+		// from an export or the API.
+		SeedDefaults *bool `json:"seed_defaults" doc:"Seed starter templates and a stylesheet. Defaults to true."`
 	} `json:"body"`
 }
 
@@ -179,7 +196,17 @@ func (h *WorkspaceHandler) Create(c *okapi.Context, req *CreateWorkspaceRequest)
 		return c.AbortInternalServerError("failed to add workspace member")
 	}
 
-	h.logAudit(c, ws.ID, "workspace.created", "Workspace created: "+ws.Name, map[string]any{"slug": ws.Slug})
+	seeded := shouldSeedWorkspace(req.Body.SeedDefaults)
+	if seeded && h.seeder != nil {
+		// Best effort and after the audit-relevant work: a workspace that exists
+		// but has no starter content is a far better outcome than a create call
+		// that fails once the row is already committed.
+		h.seeder.SeedWorkspaceDefaults(ws.ID, uint(userID), h.ownerName(uint(userID)))
+	}
+
+	h.logAudit(c, ws.ID, "workspace.created", "Workspace created: "+ws.Name, map[string]any{
+		metaSlug: ws.Slug, "seeded": seeded,
+	})
 
 	return created(c, WorkspaceResponse{
 		ID:          ws.ID,
@@ -191,6 +218,27 @@ func (h *WorkspaceHandler) Create(c *okapi.Context, req *CreateWorkspaceRequest)
 		System:      ws.System,
 		CreatedAt:   ws.CreatedAt,
 	})
+}
+
+// shouldSeedWorkspace reads the opt-out. Absent means yes: a client that
+// predates the flag, or one that simply does not care, gets the starter content
+// rather than an empty workspace.
+func shouldSeedWorkspace(flag *bool) bool {
+	return flag == nil || *flag
+}
+
+// ownerName resolves the creator's name for the seeded templates' sample data.
+// An empty result is fine: the seeder greets generically rather than naming
+// somebody.
+func (h *WorkspaceHandler) ownerName(userID uint) string {
+	if h.userRepo == nil {
+		return ""
+	}
+	user, err := h.userRepo.FindByID(userID)
+	if err != nil || user == nil {
+		return ""
+	}
+	return user.Name
 }
 
 func (h *WorkspaceHandler) List(c *okapi.Context) error {
@@ -306,7 +354,7 @@ func (h *WorkspaceHandler) Delete(c *okapi.Context) error {
 		return c.AbortInternalServerError("failed to delete workspace")
 	}
 
-	h.logAudit(c, ws.ID, "workspace.deleted", "Workspace deleted: "+ws.Name, map[string]any{"slug": ws.Slug})
+	h.logAudit(c, ws.ID, "workspace.deleted", "Workspace deleted: "+ws.Name, map[string]any{metaSlug: ws.Slug})
 
 	return noContent(c)
 }

--- a/internal/handlers/workspace_seed_test.go
+++ b/internal/handlers/workspace_seed_test.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Jonas Kaninda
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import "testing"
+
+// Absent means seed. A client that predates the flag, or one that does not set
+// it, should get a workspace it can send from rather than an empty one.
+func TestShouldSeedWorkspace(t *testing.T) {
+	yes, no := true, false
+
+	cases := []struct {
+		name string
+		flag *bool
+		want bool
+	}{
+		{"omitted", nil, true},
+		{"explicitly true", &yes, true},
+		{"explicitly false", &no, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldSeedWorkspace(tc.flag); got != tc.want {
+				t.Fatalf("shouldSeedWorkspace(%v) = %v, want %v", tc.flag, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -277,6 +277,7 @@ func InitRoutes(app *okapi.Okapi, db *gorm.DB, redisClient *redis.Client, cfg *c
 	// Plans
 	r.h.plan = handlers.NewPlanHandler(planRepo, workspaceRepo, userRepo, planService, auditLogger)
 	r.h.admin.SetWorkspaceRepo(workspaceRepo, planRepo)
+	r.h.workspace.SetSeeder(userSeeder)
 	r.h.workspace.SetPlanService(planService)
 	r.h.workspace.SetAuditLogger(auditLogger)
 	r.h.apiKey.SetQuota(planService, db)

--- a/internal/services/seeder/seeder.go
+++ b/internal/services/seeder/seeder.go
@@ -6,6 +6,7 @@ package seeder
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/goposta/posta/internal/models"
@@ -115,9 +116,15 @@ func workspacePtr(workspaceID uint) *uint {
 	return &workspaceID
 }
 
+// sampleRecipientName fills {{ name }} in the seeded templates' preview data
+// when the owner's name is unknown. It greets, rather than naming a person who
+// has nothing to do with the installation.
+const sampleRecipientName = "there"
+
 func (s *Seeder) SeedWorkspaceDefaults(workspaceID, userID uint, userName string) {
+	userName = strings.TrimSpace(userName)
 	if userName == "" {
-		userName = "Jonas"
+		userName = sampleRecipientName
 	}
 	// Scoped to the workspace being seeded, not to the user. A user's second
 	// workspace needs its own defaults, and a re-run against an already-seeded

--- a/internal/services/seeder/templates/de/welcome.html.tmpl
+++ b/internal/services/seeder/templates/de/welcome.html.tmpl
@@ -37,7 +37,7 @@
         </tr>
         <tr>
           <td class="email-footer">
-            <p>© {{year}} {{company}} — Lizenziert unter Apache 2.0</p>
+            <p>© {{year}} {{company}} — Lizenziert unter AGPL-3.0</p>
             <p><a href="{{ posta_web_view_url }}">Diese E-Mail im Browser anzeigen</a></p>
           </td>
         </tr>

--- a/internal/services/seeder/templates/de/welcome.txt.tmpl
+++ b/internal/services/seeder/templates/de/welcome.txt.tmpl
@@ -19,6 +19,6 @@ Hilfreiche Ressourcen:
 Mit freundlichen Grüßen,
 Das {{company}}-Team
 
-© {{year}} {{company}} — Lizenziert unter Apache 2.0
+© {{year}} {{company}} — Lizenziert unter AGPL-3.0
 
 Diese E-Mail im Browser anzeigen: {{ posta_web_view_url }}

--- a/internal/services/seeder/templates/en/welcome.html.tmpl
+++ b/internal/services/seeder/templates/en/welcome.html.tmpl
@@ -37,7 +37,7 @@
         </tr>
         <tr>
           <td class="email-footer">
-            <p>© {{year}} {{company}} — Licensed under Apache 2.0</p>
+            <p>© {{year}} {{company}} — Licensed under AGPL-3.0</p>
             <p><a href="{{ posta_web_view_url }}">View this email in your browser</a></p>
           </td>
         </tr>

--- a/internal/services/seeder/templates/en/welcome.txt.tmpl
+++ b/internal/services/seeder/templates/en/welcome.txt.tmpl
@@ -19,6 +19,6 @@ Helpful resources:
 Best regards,
 The {{company}} Team
 
-© {{year}} {{company}} — Licensed under Apache 2.0
+© {{year}} {{company}} — Licensed under AGPL-3.0
 
 View this email in your browser: {{ posta_web_view_url }}

--- a/internal/services/seeder/templates/fr/welcome.html.tmpl
+++ b/internal/services/seeder/templates/fr/welcome.html.tmpl
@@ -37,7 +37,7 @@
         </tr>
         <tr>
           <td class="email-footer">
-            <p>© {{year}} {{company}} — Licence Apache 2.0</p>
+            <p>© {{year}} {{company}} — Licence AGPL-3.0</p>
             <p><a href="{{ posta_web_view_url }}">Afficher cet e-mail dans votre navigateur</a></p>
           </td>
         </tr>

--- a/internal/services/seeder/templates/fr/welcome.txt.tmpl
+++ b/internal/services/seeder/templates/fr/welcome.txt.tmpl
@@ -19,6 +19,6 @@ Ressources utiles :
 Cordialement,
 L'équipe {{company}}
 
-© {{year}} {{company}} — Licence Apache 2.0
+© {{year}} {{company}} — Licence AGPL-3.0
 
 Afficher cet e-mail dans votre navigateur : {{ posta_web_view_url }}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -903,6 +903,8 @@ export interface WorkspaceInput {
   name: string
   slug?: string
   description?: string
+  /** Starter templates, stylesheet and languages. Omitted means true. */
+  seed_defaults?: boolean
 }
 
 export interface WorkspaceMember {

--- a/web/src/views/workspaces/Workspaces.vue
+++ b/web/src/views/workspaces/Workspaces.vue
@@ -19,6 +19,8 @@ const showCreateModal = ref(false)
 const newName = ref('')
 const newSlug = ref('')
 const newDescription = ref('')
+// On by default: an empty workspace has nothing to send and nothing to look at.
+const newSeedDefaults = ref(true)
 const creating = ref(false)
 
 async function fetchData() {
@@ -48,12 +50,18 @@ async function createWorkspace() {
   if (!newName.value.trim() || !newSlug.value.trim()) return
   creating.value = true
   try {
-    await workspaceApi.create({ name: newName.value.trim(), slug: newSlug.value.trim(), description: newDescription.value.trim() })
+    await workspaceApi.create({
+      name: newName.value.trim(),
+      slug: newSlug.value.trim(),
+      description: newDescription.value.trim(),
+      seed_defaults: newSeedDefaults.value,
+    })
     notify.success('Workspace created')
     showCreateModal.value = false
     newName.value = ''
     newSlug.value = ''
     newDescription.value = ''
+    newSeedDefaults.value = true
     await fetchData()
     await wsStore.fetchWorkspaces()
   } catch (err: any) {
@@ -245,6 +253,17 @@ if (route.query.create !== undefined) {
                 class="form-input"
                 placeholder="What is this workspace for?"
               />
+            </div>
+            <div class="form-group">
+              <label class="checkbox-label">
+                <input v-model="newSeedDefaults" type="checkbox" />
+                Add starter content
+              </label>
+              <span class="form-hint">
+                A welcome template in English, French and German, a default stylesheet, and the
+                matching languages — enough to send something straight away. Turn this off for a
+                workspace you will fill from an export or the API.
+              </span>
             </div>
           </div>
           <div class="modal-footer">


### PR DESCRIPTION
* feat(workspaces): seed default content into the system workspace
* fix(config): give the worker its own validation